### PR TITLE
add no_std mode; fixes #3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,11 +21,13 @@ name = "twofloat"
 test = true
 
 [features]
-default = ["math_funcs"]
-math_funcs = ["num-traits/std"]
+default = ["std", "math_funcs"]
+math_funcs = ["std"]
+std = ["num-traits/std"]
 
 [dependencies]
 hexf = "0.2"
+libm = { version = "0.2.6", optional = true }
 num-traits = { version = "0.2.14", default-features = false }
 serde = { version = "1.0", default-features = false, features = ["derive"], optional = true }
 

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -4,7 +4,7 @@ use core::ops::{
     Add, AddAssign, Div, DivAssign, Mul, MulAssign, Neg, Rem, RemAssign, Sub, SubAssign,
 };
 
-use crate::{math, TwoFloat};
+use crate::{Math, TwoFloat};
 
 pub(crate) fn fast_two_sum(a: f64, b: f64) -> TwoFloat {
     // Joldes et al. (2017) Algorithm 1
@@ -43,7 +43,7 @@ impl TwoFloat {
         let p = a * b;
         Self {
             hi: p,
-            lo: math::fma(a, b, -p),
+            lo: Math::fma(a, b, -p),
         }
     }
 
@@ -128,7 +128,7 @@ binary_ops! {
     /// (2017) Algorithm 9.
     fn Mul::mul<'a, 'b>(self: &'a TwoFloat, rhs: &'b f64) -> TwoFloat {
         let (ch, cl1) = TwoFloat::new_mul(self.hi, *rhs).into();
-        let cl3 = math::fma(self.lo, *rhs, cl1);
+        let cl3 = Math::fma(self.lo, *rhs, cl1);
         fast_two_sum(ch, cl3)
     }
 
@@ -136,7 +136,7 @@ binary_ops! {
     /// (2017) Algorithm 9.
     fn Mul::mul<'a, 'b>(self: &'a f64, rhs: &'b TwoFloat) -> TwoFloat {
         let (ch, cl1) = TwoFloat::new_mul(rhs.hi, *self).into();
-        let cl3 = math::fma(rhs.lo, *self, cl1);
+        let cl3 = Math::fma(rhs.lo, *self, cl1);
         fast_two_sum(ch, cl3)
     }
 
@@ -145,8 +145,8 @@ binary_ops! {
     fn Mul::mul<'a, 'b>(self: &'a TwoFloat, rhs: &'b TwoFloat) -> TwoFloat {
         let (ch, cl1) = TwoFloat::new_mul(self.hi, rhs.hi).into();
         let tl0 = self.lo * rhs.lo;
-        let tl1 = math::fma(self.hi, rhs.lo, tl0);
-        let cl2 = math::fma(self.lo, rhs.hi, tl1);
+        let tl1 = Math::fma(self.hi, rhs.lo, tl0);
+        let cl2 = Math::fma(self.lo, rhs.hi, tl1);
         let cl3 = cl1 + cl2;
         fast_two_sum(ch, cl3)
     }
@@ -175,7 +175,7 @@ binary_ops! {
         let d = e * th;
         let m = d + th;
         let (ch, cl1) = TwoFloat::new_mul(m.hi, *self).into();
-        let cl3 = math::fma(m.lo, *self, cl1);
+        let cl3 = Math::fma(m.lo, *self, cl1);
         fast_two_sum(ch, cl3)
     }
 
@@ -253,7 +253,7 @@ assign_ops! {
     /// (2017) Algorithm 9.
     fn MulAssign::mul_assign<'a>(self: &mut TwoFloat, rhs: &'a f64) {
         let (ch, cl1) = TwoFloat::new_mul(self.hi, *rhs).into();
-        let cl3 = math::fma(self.lo, *rhs, cl1);
+        let cl3 = Math::fma(self.lo, *rhs, cl1);
         *self = fast_two_sum(ch, cl3);
     }
 
@@ -262,8 +262,8 @@ assign_ops! {
     fn MulAssign::mul_assign<'a>(self: &mut TwoFloat, rhs: &'a TwoFloat) {
         let (ch, cl1) = TwoFloat::new_mul(self.hi, rhs.hi).into();
         let tl0 = self.lo * rhs.lo;
-        let tl1 = math::fma(self.hi, rhs.lo, tl0);
-        let cl2 = math::fma(self.lo, rhs.hi, tl1);
+        let tl1 = Math::fma(self.hi, rhs.lo, tl0);
+        let cl2 = Math::fma(self.lo, rhs.hi, tl1);
         let cl3 = cl1 + cl2;
         *self = fast_two_sum(ch, cl3)
     }

--- a/src/base.rs
+++ b/src/base.rs
@@ -2,7 +2,7 @@ use core::{cmp::Ordering, num::FpCategory};
 
 use hexf::hexf64;
 
-use crate::TwoFloat;
+use crate::{Math, TwoFloat};
 
 const DEG_PER_RAD: TwoFloat = TwoFloat {
     hi: hexf64!("0x1.ca5dc1a63c1f8p5"),
@@ -40,13 +40,13 @@ pub fn no_overlap(a: f64, b: f64) -> bool {
             }
             let bits = a.to_bits();
             let biased_exponent = ((bits >> 52) & EXPONENT_MASK) as i16;
-            let offset = if (bits & MANTISSA_MASK) == 0 && a.signum() != b.signum() {
+            let offset = if (bits & MANTISSA_MASK) == 0 && Math::signum(a) != Math::signum(b) {
                 1077
             } else {
                 1076
             };
-            let limit = ((biased_exponent - offset) as f64).exp2();
-            match b.abs().partial_cmp(&limit) {
+            let limit = Math::exp2((biased_exponent - offset) as f64);
+            match Math::abs(b).partial_cmp(&limit) {
                 Some(Ordering::Less) => true,
                 Some(Ordering::Equal) => (bits & 1) == 0,
                 _ => false,

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,6 +1,6 @@
 use core::fmt;
 
-use crate::TwoFloat;
+use crate::{Math, TwoFloat};
 
 impl fmt::Display for TwoFloat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -18,14 +18,22 @@ impl fmt::Display for TwoFloat {
                     self.hi,
                     sign_char,
                     p,
-                    self.lo.abs()
+                    Math::abs(self.lo)
                 ),
-                None => write!(f, "{:+} {} {}", self.hi, sign_char, self.lo.abs()),
+                None => write!(f, "{:+} {} {}", self.hi, sign_char, Math::abs(self.lo)),
             }
         } else {
             match f.precision() {
-                Some(p) => write!(f, "{:.*} {} {:.*}", p, self.hi, sign_char, p, self.lo.abs()),
-                None => write!(f, "{} {} {}", self.hi, sign_char, self.lo.abs()),
+                Some(p) => write!(
+                    f,
+                    "{:.*} {} {:.*}",
+                    p,
+                    self.hi,
+                    sign_char,
+                    p,
+                    Math::abs(self.lo)
+                ),
+                None => write!(f, "{} {} {}", self.hi, sign_char, Math::abs(self.lo)),
             }
         }
     }
@@ -47,9 +55,9 @@ impl fmt::LowerExp for TwoFloat {
                     self.hi,
                     sign_char,
                     p,
-                    self.lo.abs()
+                    Math::abs(self.lo)
                 ),
-                None => write!(f, "{:+e} {} {:e}", self.hi, sign_char, self.lo.abs()),
+                None => write!(f, "{:+e} {} {:e}", self.hi, sign_char, Math::abs(self.lo)),
             }
         } else {
             match f.precision() {
@@ -60,9 +68,9 @@ impl fmt::LowerExp for TwoFloat {
                     self.hi,
                     sign_char,
                     p,
-                    self.lo.abs()
+                    Math::abs(self.lo)
                 ),
-                None => write!(f, "{:e} {} {:e}", self.hi, sign_char, self.lo.abs()),
+                None => write!(f, "{:e} {} {:e}", self.hi, sign_char, Math::abs(self.lo)),
             }
         }
     }
@@ -84,9 +92,9 @@ impl fmt::UpperExp for TwoFloat {
                     self.hi,
                     sign_char,
                     p,
-                    self.lo.abs()
+                    Math::abs(self.lo)
                 ),
-                None => write!(f, "{:+E} {} {:E}", self.hi, sign_char, self.lo.abs()),
+                None => write!(f, "{:+E} {} {:E}", self.hi, sign_char, Math::abs(self.lo)),
             }
         } else {
             match f.precision() {
@@ -97,15 +105,15 @@ impl fmt::UpperExp for TwoFloat {
                     self.hi,
                     sign_char,
                     p,
-                    self.lo.abs()
+                    Math::abs(self.lo)
                 ),
-                None => write!(f, "{:E} {} {:E}", self.hi, sign_char, self.lo.abs()),
+                None => write!(f, "{:E} {} {:E}", self.hi, sign_char, Math::abs(self.lo)),
             }
         }
     }
 }
 
-#[cfg(test)]
+#[cfg(all(feature = "std", test))]
 mod test {
     use crate::TwoFloat;
 

--- a/src/functions/fraction.rs
+++ b/src/functions/fraction.rs
@@ -1,4 +1,4 @@
-use crate::{arithmetic::fast_two_sum, TwoFloat};
+use crate::{arithmetic::fast_two_sum, Math, TwoFloat};
 
 impl TwoFloat {
     /// Returns the fractional part of the number.
@@ -14,18 +14,18 @@ impl TwoFloat {
     /// assert_eq!(b, TwoFloat::new_add(-1.0, 1e-200));
     /// ```
     pub fn fract(self) -> Self {
-        let hi_fract = self.hi.fract();
-        let lo_fract = self.lo.fract();
+        let hi_fract = Math::fract(self.hi);
+        let lo_fract = Math::fract(self.lo);
         if lo_fract == 0.0 {
             hi_fract.into()
         } else if hi_fract == 0.0 {
             match (self.hi >= 0.0, self.lo >= 0.0) {
                 (true, false) => fast_two_sum(1.0, lo_fract),
                 (false, true) => fast_two_sum(-1.0, lo_fract),
-                _ => self.lo.fract().into(),
+                _ => Math::fract(self.lo).into(),
             }
         } else {
-            fast_two_sum(self.hi.fract(), self.lo)
+            fast_two_sum(Math::fract(self.hi), self.lo)
         }
     }
 
@@ -64,15 +64,15 @@ impl TwoFloat {
     /// assert_eq!(c, TwoFloat::from(0.0));
     /// ```
     pub fn ceil(self) -> Self {
-        if self.lo.fract() == 0.0 {
+        if Math::fract(self.lo) == 0.0 {
             Self {
-                hi: self.hi.ceil(),
+                hi: Math::ceil(self.hi),
                 lo: self.lo,
             }
-        } else if self.hi.fract() == 0.0 {
-            fast_two_sum(self.hi, self.lo.ceil())
+        } else if Math::fract(self.hi) == 0.0 {
+            fast_two_sum(self.hi, Math::ceil(self.lo))
         } else {
-            self.hi.ceil().into()
+            Math::ceil(self.hi).into()
         }
     }
 
@@ -91,15 +91,15 @@ impl TwoFloat {
     /// assert_eq!(c, TwoFloat::from(-1.0));
     /// ```
     pub fn floor(self) -> Self {
-        if self.lo.fract() == 0.0 {
+        if Math::fract(self.lo) == 0.0 {
             Self {
-                hi: self.hi.floor(),
+                hi: Math::floor(self.hi),
                 lo: self.lo,
             }
-        } else if self.hi.fract() == 0.0 {
-            fast_two_sum(self.hi, self.lo.floor())
+        } else if Math::fract(self.hi) == 0.0 {
+            fast_two_sum(self.hi, Math::floor(self.lo))
         } else {
-            self.hi.floor().into()
+            Math::floor(self.hi).into()
         }
     }
 
@@ -119,29 +119,29 @@ impl TwoFloat {
     /// assert_eq!(c, TwoFloat::from(-1.0));
     /// ```
     pub fn round(self) -> Self {
-        if self.lo.fract() == 0.0 {
+        if Math::fract(self.lo) == 0.0 {
             Self {
-                hi: self.hi.round(),
+                hi: Math::round(self.hi),
                 lo: self.lo(),
             }
-        } else if self.hi.fract() == 0.0 {
-            if self.lo.fract().abs() == 0.5 {
+        } else if Math::fract(self.hi) == 0.0 {
+            if Math::abs(Math::fract(self.lo)) == 0.5 {
                 if self.is_sign_positive() {
-                    fast_two_sum(self.hi, self.lo.ceil())
+                    fast_two_sum(self.hi, Math::ceil(self.lo))
                 } else {
-                    fast_two_sum(self.hi, self.lo.floor())
+                    fast_two_sum(self.hi, Math::floor(self.lo))
                 }
             } else {
-                fast_two_sum(self.hi, self.lo.round())
+                fast_two_sum(self.hi, Math::round(self.lo))
             }
-        } else if self.hi.fract().abs() == 0.5 {
+        } else if Math::abs(Math::fract(self.hi)) == 0.5 {
             if self.hi.is_sign_positive() == self.lo.is_sign_positive() {
-                self.hi.round().into()
+                Math::round(self.hi).into()
             } else {
-                self.hi.trunc().into()
+                Math::trunc(self.hi).into()
             }
         } else {
-            self.hi.round().into()
+            Math::round(self.hi).into()
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,26 +64,12 @@ implementation, which may have variations between platforms.
 #![allow(clippy::float_cmp)]
 #![allow(clippy::suspicious_arithmetic_impl)]
 #![allow(clippy::suspicious_op_assign_impl)]
+#![cfg_attr(not(feature = "std"), no_std)]
 
 use core::fmt;
-use std::error;
 
-// MinGW needs to use libm FMA
-#[cfg(not(all(windows, target_env = "gnu")))]
-mod math {
-    #[inline(always)]
-    pub fn fma(a: f64, b: f64, c: f64) -> f64 {
-        a.mul_add(b, c)
-    }
-}
-
-#[cfg(all(windows, target_env = "gnu"))]
-mod math {
-    #[inline(always)]
-    pub fn fma(a: f64, b: f64, c: f64) -> f64 {
-        libm::fma(a, b, c)
-    }
-}
+mod math_util;
+pub(crate) use math_util::Math;
 
 #[macro_use]
 mod ops_util;
@@ -158,4 +144,5 @@ impl fmt::Display for TwoFloatError {
     }
 }
 
-impl error::Error for TwoFloatError {}
+#[cfg(feature = "std")]
+impl std::error::Error for TwoFloatError {}

--- a/src/math_util.rs
+++ b/src/math_util.rs
@@ -1,0 +1,85 @@
+/// A wrapper struct for mathematical operations on `f64`s.
+///
+/// It uses "libm" if it's enabled, which is required for "no_std".
+/// Fallbacks to "std" otherwise.
+pub(crate) struct Math;
+
+#[cfg(feature = "libm")]
+impl Math {
+    #[inline(always)]
+    pub fn abs(x: f64) -> f64 {
+        libm::fabs(x)
+    }
+    #[inline(always)]
+    pub fn ceil(x: f64) -> f64 {
+        libm::ceil(x)
+    }
+    #[inline(always)]
+    pub fn exp2(x: f64) -> f64 {
+        libm::exp2(x)
+    }
+    #[inline(always)]
+    pub fn floor(x: f64) -> f64 {
+        libm::floor(x)
+    }
+    #[inline(always)]
+    pub fn fma(a: f64, b: f64, c: f64) -> f64 {
+        libm::fma(a, b, c)
+    }
+    #[inline(always)]
+    pub fn fract(x: f64) -> f64 {
+        libm::modf(x).0
+    }
+    #[inline(always)]
+    pub fn round(x: f64) -> f64 {
+        libm::round(x)
+    }
+    #[inline(always)]
+    pub fn signum(x: f64) -> f64 {
+        libm::copysign(1., x)
+    }
+    #[inline(always)]
+    pub fn trunc(x: f64) -> f64 {
+        libm::trunc(x)
+    }
+}
+
+#[cfg(not(feature = "libm"))]
+impl Math {
+    #[inline(always)]
+    pub fn abs(x: f64) -> f64 {
+        x.abs()
+    }
+    #[inline(always)]
+    pub fn ceil(x: f64) -> f64 {
+        x.ceil()
+    }
+    #[inline(always)]
+    pub fn exp2(x: f64) -> f64 {
+        x.exp2()
+    }
+    #[inline(always)]
+    pub fn floor(x: f64) -> f64 {
+        x.floor()
+    }
+    #[inline(always)]
+    pub fn fma(a: f64, b: f64, c: f64) -> f64 {
+        a.mul_add(b, c)
+    }
+    #[inline(always)]
+    pub fn fract(x: f64) -> f64 {
+        x.fract()
+    }
+    #[inline(always)]
+    pub fn round(x: f64) -> f64 {
+        x.round()
+    }
+    #[inline(always)]
+    pub fn signum(x: f64) -> f64 {
+        x.signum()
+    }
+    #[inline(always)]
+    pub fn trunc(x: f64) -> f64 {
+        x.trunc()
+    }
+}

--- a/src/num_integration.rs
+++ b/src/num_integration.rs
@@ -3,7 +3,7 @@ use core::{convert::TryFrom, num::FpCategory};
 use hexf::hexf64;
 use num_traits::{Inv, Pow};
 
-use crate::{consts, TwoFloat, TwoFloatError};
+use crate::{consts, Math, TwoFloat, TwoFloatError};
 
 impl num_traits::Num for TwoFloat {
     type FromStrRadixErr = TwoFloatError;
@@ -98,7 +98,7 @@ impl num_traits::FromPrimitive for TwoFloat {
     }
 
     fn from_isize(n: isize) -> Option<Self> {
-        match std::mem::size_of::<isize>() {
+        match core::mem::size_of::<isize>() {
             1 => Self::from_i8(n as i8),
             2 => Self::from_i16(n as i16),
             4 => Self::from_i32(n as i32),
@@ -134,7 +134,7 @@ impl num_traits::FromPrimitive for TwoFloat {
     }
 
     fn from_usize(n: usize) -> Option<Self> {
-        match std::mem::size_of::<usize>() {
+        match core::mem::size_of::<usize>() {
             1 => Self::from_u8(n as u8),
             2 => Self::from_u16(n as u16),
             4 => Self::from_u32(n as u32),
@@ -172,7 +172,7 @@ impl num_traits::ToPrimitive for TwoFloat {
     }
 
     fn to_isize(&self) -> Option<isize> {
-        match std::mem::size_of::<isize>() {
+        match core::mem::size_of::<isize>() {
             1 => self.to_i8().map(|i| i as isize),
             2 => self.to_i16().map(|i| i as isize),
             4 => self.to_i32().map(|i| i as isize),
@@ -208,7 +208,7 @@ impl num_traits::ToPrimitive for TwoFloat {
     }
 
     fn to_usize(&self) -> Option<usize> {
-        match std::mem::size_of::<usize>() {
+        match core::mem::size_of::<usize>() {
             1 => self.to_u8().map(|u| u as usize),
             2 => self.to_u16().map(|u| u as usize),
             4 => self.to_u32().map(|u| u as usize),
@@ -223,7 +223,7 @@ impl num_traits::NumCast for TwoFloat {
     fn from<T: num_traits::ToPrimitive>(n: T) -> Option<Self> {
         const INT_THRESHOLD: f64 = hexf64!("0x1.0p53");
         if let Some(f) = n.to_f64() {
-            if f.abs() <= INT_THRESHOLD {
+            if Math::abs(f) <= INT_THRESHOLD {
                 Some(f.into())
             } else if let Some(i) = n.to_i128() {
                 Some(i.into())


### PR DESCRIPTION
- add default "std" feature.
- only impl `std::error::Error` when "std" is enabled.
- change `std::mem` to `core::mem` references.

All tests pass both when invoked with and without the "std" feature.