### PR TITLE
add missing closing triple backticks

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -318,6 +318,7 @@ impl TwoFloat {
     /// assert_eq!((-a).div_euclid(b), TwoFloat::from(-2.0));
     /// assert_eq!(a.div_euclid(-b), TwoFloat::from(-1.0));
     /// assert_eq!((-a).div_euclid(-b), TwoFloat::from(2.0));
+    /// ```
     pub fn div_euclid(self, rhs: Self) -> Self {
         let quotient = (self / rhs).trunc();
         if (self - quotient * rhs) < 0.0 {
@@ -348,6 +349,7 @@ impl TwoFloat {
     /// assert_eq!((-a).rem_euclid(b), TwoFloat::from(1.0));
     /// assert_eq!(a.rem_euclid(-b), TwoFloat::from(4.0));
     /// assert_eq!((-a).rem_euclid(-b), TwoFloat::from(1.0));
+    /// ```
     pub fn rem_euclid(self, rhs: Self) -> Self {
         let remainder = self % rhs;
         if remainder < 0.0 {

--- a/src/base.rs
+++ b/src/base.rs
@@ -34,6 +34,7 @@ fn exponent(x: f64) -> u32 {
 /// assert!(a);
 /// assert!(!b);
 /// assert!(!c);
+/// ```
 pub fn no_overlap(a: f64, b: f64) -> bool {
     match (a.classify(), b.classify()) {
         (FpCategory::Normal, FpCategory::Normal) => {
@@ -106,6 +107,7 @@ impl TwoFloat {
     /// # use twofloat::TwoFloat;
     /// const value: TwoFloat = TwoFloat::from_f64(1.0);
     /// assert_eq!(value.hi(), 1.0);
+    /// ```
     pub const fn from_f64(value: f64) -> Self {
         TwoFloat { hi: value, lo: 0.0 }
     }
@@ -118,6 +120,7 @@ impl TwoFloat {
     /// # use twofloat::TwoFloat;
     /// let value = TwoFloat::new_add(1.0, -1.0e-200);
     /// assert_eq!(value.hi(), 1.0);
+    /// ```
     pub fn hi(&self) -> f64 {
         self.hi
     }
@@ -130,6 +133,7 @@ impl TwoFloat {
     /// # use twofloat::TwoFloat;
     /// let value = TwoFloat::new_add(1.0, -1.0e-200);
     /// assert_eq!(value.lo(), -1.0e-200);
+    /// ```
     pub fn lo(&self) -> f64 {
         self.lo
     }
@@ -146,6 +150,7 @@ impl TwoFloat {
     ///
     /// assert!(a);
     /// assert!(!b);
+    /// ```
     pub fn is_valid(&self) -> bool {
         self.hi.is_finite() && self.lo.is_finite() && no_overlap(self.hi, self.lo)
     }
@@ -161,6 +166,7 @@ impl TwoFloat {
     /// let b = TwoFloat::new_add(35.2, -1e-93);
     ///
     /// assert_eq!(a.min(b), b);
+    /// ```
     pub fn min(self, other: Self) -> Self {
         if !self.is_valid() {
             other
@@ -182,6 +188,7 @@ impl TwoFloat {
     /// let b = TwoFloat::new_add(35.2, -1e-93);
     ///
     /// assert_eq!(a.max(b), a);
+    /// ```
     pub fn max(self, other: Self) -> Self {
         if !self.is_valid() {
             other
@@ -202,6 +209,7 @@ impl TwoFloat {
     /// let b = a.to_radians();
     ///
     /// assert!((b - twofloat::consts::FRAC_PI_2).abs() < 1e-16);
+    /// ```
     pub fn to_radians(self) -> Self {
         self * RAD_PER_DEG
     }
@@ -215,6 +223,7 @@ impl TwoFloat {
     /// let b = a.to_degrees();
     ///
     /// assert!((b - 180.0).abs() < 1e-16);
+    /// ```
     pub fn to_degrees(self) -> Self {
         self * DEG_PER_RAD
     }
@@ -230,6 +239,7 @@ impl TwoFloat {
     /// let difference = b.recip() - a;
     ///
     /// assert!(difference.abs() < 1e-16);
+    /// ```
     pub fn recip(self) -> Self {
         1.0 / self
     }
@@ -245,6 +255,7 @@ impl TwoFloat {
     ///
     /// assert!(a - TwoFloat::from(8.0) <= 1e-16);
     /// assert!(!b.is_valid());
+    /// ```
     pub fn powi(self, n: i32) -> Self {
         match n {
             0 => {

--- a/src/functions/explog.rs
+++ b/src/functions/explog.rs
@@ -192,6 +192,7 @@ impl TwoFloat {
     /// let e2 = twofloat::consts::E * twofloat::consts::E;
     ///
     /// assert!((b - e2).abs() / e2 < 1e-16);
+    /// ```
     pub fn exp(self) -> Self {
         if self.hi <= EXP_LOWER_LIMIT {
             Self::from(0.0)
@@ -250,6 +251,7 @@ impl TwoFloat {
     /// let c = 0.05f64.exp_m1();
     ///
     /// assert!((b - c).abs() < 1e-16);
+    /// ```
     pub fn exp_m1(self) -> Self {
         if self < -LN_2 || self > LN_FRAC_3_2 {
             self.exp() - 1.0
@@ -269,6 +271,7 @@ impl TwoFloat {
     /// let b = TwoFloat::from(2).sqrt();
     ///
     /// assert!((a - b).abs() < 1e-15);
+    /// ```
     pub fn exp2(self) -> Self {
         if self < -1074.0 {
             Self::from(0.0)
@@ -302,6 +305,7 @@ impl TwoFloat {
     /// ```
     /// let a = twofloat::consts::E.ln();
     /// assert!((a - 1.0).abs() < 1e-11);
+    /// ```
     pub fn ln(self) -> Self {
         if self == 1.0 {
             Self::from(0.0)
@@ -327,6 +331,7 @@ impl TwoFloat {
     /// let b = a.ln_1p();
     /// let c = 0.1f64.ln_1p();
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn ln_1p(self) -> Self {
         if self == 0.0 {
             Self::from(0.0)
@@ -369,6 +374,7 @@ impl TwoFloat {
     /// let a = TwoFloat::from(64.0).log2();
     ///
     /// assert!((a - 6.0).abs() < 1e-12, "{}", a);
+    /// ```
     pub fn log2(self) -> Self {
         if self == 1.0 {
             Self::from(1.0)
@@ -393,6 +399,7 @@ impl TwoFloat {
     /// let a = TwoFloat::from(100.0).log10();
     ///
     /// assert!((a - 2.0).abs() < 1e-12);
+    /// ```
     pub fn log10(self) -> Self {
         self.ln() / LN_10
     }

--- a/src/functions/fraction.rs
+++ b/src/functions/fraction.rs
@@ -13,6 +13,7 @@ impl TwoFloat {
     ///
     /// assert_eq!(a, TwoFloat::from(1e-200));
     /// assert_eq!(b, TwoFloat::new_add(-1.0, 1e-200));
+    /// ```
     pub fn fract(self) -> Self {
         let hi_fract = self.hi.fract();
         let lo_fract = self.lo.fract();
@@ -40,6 +41,7 @@ impl TwoFloat {
     ///
     /// assert_eq!(a, TwoFloat::from(1.0));
     /// assert_eq!(b, TwoFloat::from(0.0));
+    /// ```
     pub fn trunc(self) -> Self {
         if self.is_sign_positive() {
             self.floor()
@@ -61,6 +63,7 @@ impl TwoFloat {
     /// assert_eq!(a, TwoFloat::from(2.0));
     /// assert_eq!(b, TwoFloat::from(1.0));
     /// assert_eq!(c, TwoFloat::from(0.0));
+    /// ```
     pub fn ceil(self) -> Self {
         if self.lo.fract() == 0.0 {
             Self {
@@ -87,6 +90,7 @@ impl TwoFloat {
     /// assert_eq!(a, TwoFloat::from(1.0));
     /// assert_eq!(b, TwoFloat::from(0.0));
     /// assert_eq!(c, TwoFloat::from(-1.0));
+    /// ```
     pub fn floor(self) -> Self {
         if self.lo.fract() == 0.0 {
             Self {
@@ -114,6 +118,7 @@ impl TwoFloat {
     /// assert_eq!(a, TwoFloat::from(1.0));
     /// assert_eq!(b, TwoFloat::from(1.0));
     /// assert_eq!(c, TwoFloat::from(-1.0));
+    /// ```
     pub fn round(self) -> Self {
         if self.lo.fract() == 0.0 {
             Self {

--- a/src/functions/hyperbolic.rs
+++ b/src/functions/hyperbolic.rs
@@ -15,6 +15,7 @@ impl TwoFloat {
     /// let c = 2.0f64.cosh();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn cosh(self) -> Self {
         self.exp() / 2.0 + (-self).exp() / 2.0
     }
@@ -33,6 +34,7 @@ impl TwoFloat {
     /// let c = 2.0f64.sinh();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn sinh(self) -> Self {
         self.exp() / 2.0 - (-self).exp() / 2.0
     }
@@ -51,6 +53,7 @@ impl TwoFloat {
     /// let c = 2.0f64.tanh();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn tanh(self) -> Self {
         let e_plus = self.exp();
         let e_minus = (-self).exp();
@@ -71,6 +74,7 @@ impl TwoFloat {
     /// let c = 2.0f64.acosh();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn acosh(self) -> Self {
         (self + (self * self - 1.0).sqrt()).ln()
     }
@@ -89,6 +93,7 @@ impl TwoFloat {
     /// let c = 2.0f64.asinh();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn asinh(self) -> Self {
         (self + (self * self + 1.0).sqrt()).ln()
     }
@@ -107,6 +112,7 @@ impl TwoFloat {
     /// let c = 0.5f64.atanh();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn atanh(self) -> Self {
         ((1.0 + self) / (1.0 - self)).ln() / 2.0
     }

--- a/src/functions/power.rs
+++ b/src/functions/power.rs
@@ -12,6 +12,7 @@ impl TwoFloat {
     /// let b = a.sqrt();
     ///
     /// assert!(b * b - a < 1e-16);
+    /// ```
     pub fn sqrt(self) -> Self {
         if self.hi < 0.0 || (self.hi == 0.0 && self.lo < 0.0) {
             Self::NAN
@@ -34,6 +35,7 @@ impl TwoFloat {
     /// let b = a.cbrt();
     ///
     /// assert!(b.powi(3) - a < 1e-16);
+    /// ```
     pub fn cbrt(self) -> Self {
         let mut x = Self::from(self.hi.cbrt());
         let mut x2 = x * x;
@@ -54,6 +56,7 @@ impl TwoFloat {
     /// let c = TwoFloat::hypot(a, b);
     ///
     /// assert!((c - 5.0).abs() < 1e-10);
+    /// ```
     pub fn hypot(self, other: Self) -> Self {
         (self * self + other * other).sqrt()
     }
@@ -72,6 +75,7 @@ impl TwoFloat {
     /// let c = a.powf(b);
     ///
     /// assert!((c + 125.0).abs() < 1e-9, "{}", c);
+    /// ```
     pub fn powf(self, y: Self) -> Self {
         match (self == 0.0, y == 0.0) {
             (true, true) => Self::NAN,

--- a/src/functions/sign.rs
+++ b/src/functions/sign.rs
@@ -12,6 +12,7 @@ impl TwoFloat {
     ///
     /// assert_eq!(a, TwoFloat::new_add(1.0, 1.0e-300));
     /// assert_eq!(b, TwoFloat::new_add(1.0, -1.0e-300));
+    /// ```
     pub fn abs(&self) -> Self {
         if self.hi > 0.0
             || (self.hi == 0.0 && self.hi.is_sign_positive() && self.lo.is_sign_positive())
@@ -35,6 +36,7 @@ impl TwoFloat {
     /// assert!(a);
     /// assert!(b);
     /// assert!(!c);
+    /// ```
     pub fn is_sign_positive(&self) -> bool {
         self.hi.is_sign_positive()
     }
@@ -52,6 +54,7 @@ impl TwoFloat {
     /// assert!(a);
     /// assert!(!b);
     /// assert!(!c);
+    /// ```
     pub fn is_sign_negative(&self) -> bool {
         self.hi.is_sign_negative()
     }
@@ -71,6 +74,7 @@ impl TwoFloat {
     /// let c = a.copysign(&b);
     ///
     /// assert_eq!(c, -a);
+    /// ```
     pub fn copysign(&self, sign: &Self) -> Self {
         if self.is_sign_positive() == sign.is_sign_positive() {
             *self

--- a/src/functions/trigonometry.rs
+++ b/src/functions/trigonometry.rs
@@ -300,6 +300,7 @@ impl TwoFloat {
     /// let c = 2.5f64.sin();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn sin(self) -> Self {
         if !self.is_valid() {
             return Self::NAN;
@@ -324,6 +325,7 @@ impl TwoFloat {
     /// let c = 2.5f64.cos();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn cos(self) -> Self {
         if !self.is_valid() {
             return Self::NAN;
@@ -350,6 +352,7 @@ impl TwoFloat {
     ///
     /// assert!((s - 2.5f64.sin()).abs() < 1e-10);
     /// assert!((c - 2.5f64.cos()).abs() < 1e-10);
+    /// ```
     pub fn sin_cos(self) -> (Self, Self) {
         if !self.is_valid() {
             return (Self::NAN, Self::NAN);
@@ -376,6 +379,7 @@ impl TwoFloat {
     /// let c = 2.5f64.tan();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn tan(self) -> Self {
         if !self.is_valid() {
             return self;
@@ -400,6 +404,7 @@ impl TwoFloat {
     /// let c = 0.7f64.asin();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn asin(self) -> Self {
         let abs_val = self.abs();
         if !self.is_valid() || abs_val > 1.0 {
@@ -429,6 +434,7 @@ impl TwoFloat {
     /// let c = (-0.8f64).acos();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn acos(self) -> Self {
         let x = self.asin();
         if x.is_valid() {
@@ -450,6 +456,7 @@ impl TwoFloat {
     /// let c = 3.5f64.atan();
     ///
     /// assert!((b - c).abs() < 1e-10);
+    /// ```
     pub fn atan(self) -> Self {
         if !self.is_valid() {
             Self::NAN
@@ -496,6 +503,7 @@ impl TwoFloat {
     /// let theta = TwoFloat::atan2(y, x);
     ///
     /// assert!((theta + 3.0 * twofloat::consts::FRAC_PI_4).abs() < 1e-10);
+    /// ```
     pub fn atan2(self, other: Self) -> Self {
         if self.hi == 0.0 {
             if other.hi.is_sign_positive() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ The basic type is `TwoFloat` which represents the sum of two non-overlapping
 `f64` values, which may be initialized from a single `f64` or by calling a
 constructor that performs an arithmetic operation on a pair of `f64` values.
 
-```.rust
+```
 extern crate twofloat;
 use twofloat::TwoFloat;
 


### PR DESCRIPTION
continuing the conversation from [ #10 ](https://github.com/ajtribick/twofloat/pull/10#issuecomment-1180758369)

> I think the example I was looking at when I was making the project initially didn't close the code blocks when they were at the end of the comment block, so I didn't either. It seems to be valid from the point of view of doctest discovery and documentation generation, so maybe that's a bug in the Vim plugin? I'm not opposed to changing it though.

I've tried finding examples or specs regarding missing closing codeblocks ticks, and couldn't find anything illuminating in that regard. Every example I can find closes the codeblocks, and since I'm using the [official rust vim plugin](https://github.com/rust-lang/rust.vim/) and you're open to add the closing triple backticks, this PR does just that.

It also removes one unnecessary codeblock language specification.