### PR TITLE
Fix definition of no_overlap, MIN and MAX constants

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Version 0.6
+
+* Breaking change: fix definition of no_overlap to match definition 1.4 in
+  Joldes et al. (2017).
+* Breaking change: Correct values of `MIN` and `MAX` constants.
+
 ## Version 0.5
 
 * Add operator overloads for `&f64`.


### PR DESCRIPTION
Better agreement with the source papers. This also revealed an error in the definition of the MIN and MAX constants.