### PR TITLE
add to_f64 to the Primitive conversions

### DIFF
--- a/src/num_integration.rs
+++ b/src/num_integration.rs
@@ -217,6 +217,10 @@ impl num_traits::ToPrimitive for TwoFloat {
             _ => None,
         }
     }
+    #[inline]
+    fn to_f64(&self) -> Option<f64> {
+        Some(self.into())
+    }
 }
 
 impl num_traits::NumCast for TwoFloat {

--- a/tests/convert_tests.rs
+++ b/tests/convert_tests.rs
@@ -2,7 +2,7 @@
 
 use core::{convert::TryFrom, fmt::Debug, mem::discriminant, ops::Range};
 
-use num_traits::{one, zero};
+use num_traits::{one, zero, ToPrimitive};
 use rand::{distributions::uniform::SampleUniform, Rng};
 
 use twofloat::{no_overlap, TwoFloat, TwoFloatError};
@@ -158,6 +158,19 @@ fn from_f64_test() {
 #[test]
 fn into_f64_test() {
     into_float::<f64>();
+}
+
+#[test]
+fn to_f64_test() {
+    repeated_test(|| {
+        let source = get_twofloat();
+        let result = source.to_f64().unwrap();
+        assert_eq!(
+            result,
+            source.hi(),
+            "Float conversion from TwoFloat failed"
+        );
+    });
 }
 
 fn check_try_from_result<T>(

--- a/tests/convert_tests.rs
+++ b/tests/convert_tests.rs
@@ -165,11 +165,7 @@ fn to_f64_test() {
     repeated_test(|| {
         let source = get_twofloat();
         let result = source.to_f64().unwrap();
-        assert_eq!(
-            result,
-            source.hi(),
-            "Float conversion from TwoFloat failed"
-        );
+        assert_eq!(result, source.hi(), "Float conversion from TwoFloat failed");
     });
 }
 


### PR DESCRIPTION
I had to add 

```rust
    pub fn to_f64(&self) -> Option<f64> {
        Some(self.into())
    }
``` 
into `num_integration.rs` to be able to use `to_f64()` correctly 
Before it was cutting out any decimal quantity.
