### PR TITLE
Fix powf when checking when negative

### DIFF
--- a/src/functions/power.rs
+++ b/src/functions/power.rs
@@ -84,14 +84,14 @@ impl TwoFloat {
             (false, false) => {
                 if self.is_sign_positive() {
                     (y * self.ln()).exp()
-                } else if libm::modf(self.hi).0 != 0.0 || libm::modf(self.lo).0 != 0.0 {
+                } else if libm::modf(y.hi).0 != 0.0 || libm::modf(y.lo).0 != 0.0 {
                     Self::NAN
                 } else {
                     let abs_result = (y * self.abs().ln()).exp();
-                    let low_trunc = if libm::trunc(self.lo) == 0.0 {
-                        libm::trunc(self.hi)
+                    let low_trunc = if libm::trunc(y.lo) == 0.0 {
+                        libm::trunc(y.hi)
                     } else {
-                        libm::trunc(self.lo)
+                        libm::trunc(y.lo)
                     };
 
                     if low_trunc % 2.0 == 0.0 {

--- a/tests/power_tests.rs
+++ b/tests/power_tests.rs
@@ -227,3 +227,60 @@ fn powf_test() {
         );
     });
 }
+
+#[test]
+fn powf_integers_test() {
+    let mut rng = rand::thread_rng();
+    let value_dist = rand::distributions::Uniform::new(-20.0f64, 20.0f64);
+    repeated_test(|| {
+        let a = rng.sample(value_dist);
+        let b = rng.sample(value_dist).floor();
+
+        let expected = a.powf(b);
+        let result = TwoFloat::from(a).powf(TwoFloat::from(b));
+        if expected.is_nan() {
+            assert!(result.hi().is_nan());
+            assert!(result.lo().is_nan());
+        } else {
+            let difference = (result - expected).abs().hi() / expected;
+
+            assert!(
+                difference < 1e-8,
+                "{}^{} resulted in different value {} vs {}",
+                a,
+                b,
+                result,
+                expected
+            );
+        }
+    });
+}
+
+#[test]
+fn powf_negative_test() {
+    let mut rng = rand::thread_rng();
+    let value_dist = rand::distributions::Uniform::new(-20.0f64, 20.0f64);
+    repeated_test(|| {
+        let a = rng.sample(value_dist);
+        let b = rng.sample(value_dist);
+
+        let expected = a.powf(b);
+        let result = TwoFloat::from(a).powf(TwoFloat::from(b));
+        //println!("{}^{} :{} | {}", a,b,expected, Into::<f64>::into(result));
+        if expected.is_nan() {
+            assert!(result.hi().is_nan());
+            assert!(result.lo().is_nan());
+        } else {
+            let difference = (result - expected).abs().hi() / expected;
+
+            assert!(
+                difference < 1e-8,
+                "{}^{} resulted in different value {} vs {}",
+                a,
+                b,
+                result,
+                expected
+            );
+        }
+    });
+}


### PR DESCRIPTION
One should check if the exponent is an integer when it takes negative values. (see https://github.com/ajtribick/twofloat/issues/39)

There was a bug and the one being checked was the `self` value.

I've also added tests to check for generic values of value and exponent.