### PR TITLE
Fix Precision to match Double-Double

### DIFF
--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -19,6 +19,16 @@ fn fma(x: f64, y: f64, z: f64) -> f64 {
     libm::fma(x, y, z)
 }
 
+/// Renormalization ensures that the components of the returned tuple are arranged in such a
+/// way that the absolute value of the last component is no more than half the ULP of the
+/// first.
+#[inline]
+pub fn renorm3(a: f64, b: f64, c: f64) -> TwoFloat {
+    let u = fast_two_sum(a, b);
+    let v = fast_two_sum(c, u.hi);
+    fast_two_sum(v.hi, u.lo + v.lo)
+}
+
 pub(crate) fn fast_two_sum(a: f64, b: f64) -> TwoFloat {
     // Joldes et al. (2017) Algorithm 1
     let s = a + b;
@@ -176,33 +186,26 @@ binary_ops! {
         fast_two_sum(th, tl)
     }
 
-    /// Implements division of `f64` and `TwoFloat` using Joldes et al. (2017)
-    /// Algorithm 18 modified for the left-hand side having a zero value in
-    /// the low word.
+    /// Former implements division from Joldes et al. (2017) Algorithm 18
+    /// Now taken from qd crate using long division
     fn Div::div<'a, 'b>(self: &'a f64, rhs: &'b TwoFloat) -> TwoFloat {
-        let th = rhs.hi.recip();
-        let rh = 1.0 - rhs.hi * th;
-        let rl = -(rhs.lo * th);
-        let (eh, el) = fast_two_sum(rh, rl).into();
-        let e = TwoFloat { hi: eh, lo: el };
-        let d = e * th;
-        let m = d + th;
-        let (ch, cl1) = TwoFloat::new_mul(m.hi, *self).into();
-        let cl3 = fma(m.lo, *self, cl1);
-        fast_two_sum(ch, cl3)
+                let q1 = self / rhs.hi;
+                let mut r = self - (rhs* q1);
+                let q2 = r.hi / rhs.hi;
+                r -=rhs* q2;
+                let q3 = r.hi / rhs.hi;
+                renorm3(q1, q2, q3)
     }
 
-    /// Implements division of two `TwoFloat` values using Joldes et al.
-    /// (2017) Algorithm 18.
+    /// Former implements division from Joldes et al. (2017) Algorithm 18
+    /// Now taken from qd crate using long division
     fn Div::div<'a, 'b>(self: &'a TwoFloat, rhs: &'b TwoFloat) -> TwoFloat {
-        let th = rhs.hi.recip();
-        let rh = 1.0 - rhs.hi * th;
-        let rl = -(rhs.lo * th);
-        let (eh, el) = fast_two_sum(rh, rl).into();
-        let e = TwoFloat { hi: eh, lo: el };
-        let d = e * th;
-        let m = d + th;
-        self * m
+                let q1 = self.hi / rhs.hi;
+                let mut r = self - (rhs* q1);
+                let q2 = r.hi / rhs.hi;
+                r -=rhs* q2;
+                let q3 = r.hi / rhs.hi;
+                renorm3(q1, q2, q3)
     }
 
     fn Rem::rem<'a, 'b>(self: &'a TwoFloat, rhs: &'b f64) -> TwoFloat {

--- a/src/arithmetic.rs
+++ b/src/arithmetic.rs
@@ -296,17 +296,15 @@ assign_ops! {
         *self = fast_two_sum(th, tl)
     }
 
-    /// Implements division of two `TwoFloat` values using Joldes et al.
-    /// (2017) Algorithm 18.
+    /// Former implements division from Joldes et al. (2017) Algorithm 18
+    /// Now taken from qd crate using long division
     fn DivAssign::div_assign<'a>(self: &mut TwoFloat, rhs: &'a TwoFloat) {
-        let th = rhs.hi.recip();
-        let rh = 1.0 - rhs.hi * th;
-        let rl = -(rhs.lo * th);
-        let (eh, el) = fast_two_sum(rh, rl).into();
-        let e = TwoFloat { hi: eh, lo: el };
-        let d = e * th;
-        let m = d + th;
-        *self *= m;
+        let q1 = self.hi / rhs.hi;
+        let mut r = *self - (rhs* q1);
+        let q2 = r.hi / rhs.hi;
+        r -=rhs* q2;
+        let q3 = r.hi / rhs.hi;
+        *self = renorm3(q1, q2, q3)
     }
 
     fn RemAssign::rem_assign<'b>(self: &mut TwoFloat, rhs: &'b f64) {

--- a/src/base.rs
+++ b/src/base.rs
@@ -60,6 +60,10 @@ pub fn no_overlap(a: f64, b: f64) -> bool {
 }
 
 impl TwoFloat {
+    /// Mantissa size of the double-double structure of TwoFloat
+    /// aka the number of digits in base 2
+    pub const MANTISSA: u32 = 106;
+
     /// Smallest finite `TwoFloat` value.
     pub const MIN: Self = Self {
         hi: f64::MIN,

--- a/src/base.rs
+++ b/src/base.rs
@@ -61,8 +61,8 @@ pub fn no_overlap(a: f64, b: f64) -> bool {
 
 impl TwoFloat {
     /// Mantissa size of the double-double structure of TwoFloat
-    /// aka the number of digits in base 2
-    pub const MANTISSA: u32 = 106;
+    /// aka the number of significant digits in base 2
+    pub const MANTISSA_DIGITS: u32 = 106;
 
     /// Smallest finite `TwoFloat` value.
     pub const MIN: Self = Self {

--- a/src/functions/explog.rs
+++ b/src/functions/explog.rs
@@ -947,6 +947,8 @@ impl TwoFloat {
             }
         } else if self.hi == 0.0 {
             Self::from(1.0)
+        } else if self.hi.is_nan() {
+            Self::NAN
         } else {
             // Compute the exponential of x = y/2 + z
             // Where y = round(2*x) giving z <= 0.25

--- a/src/functions/explog.rs
+++ b/src/functions/explog.rs
@@ -21,8 +21,8 @@ const LN_FRAC_3_2: TwoFloat = TwoFloat {
 };
 
 // limits
-const EXP_UPPER_LIMIT: f64 = hexf64!("0x1.62e42fefa39efp9"); // ln(0x1.0p1024)
-const EXP_LOWER_LIMIT: f64 = hexf64!("-0x1.74385446d71c3p9"); // ln(0x1.0p-1074)
+const EXP_UPPER_LIMIT: f64 = 709.0;
+const EXP_LOWER_LIMIT: f64 = -709.0;
 
 const FRAC_FACT: [TwoFloat; 21] = [
     TwoFloat {
@@ -148,8 +148,784 @@ fn mul_pow2(mut x: f64, mut y: i32) -> f64 {
     }
 }
 
+/// Exact results for the expression `exp(n/128) - 1` for `|n| <= 32`
+fn expm1_128th(n: i32) -> TwoFloat {
+    assert!(n.abs() <= 32);
+
+    const EXPM1_128TH: [TwoFloat; 65] = [
+        TwoFloat {
+            // exp(-32/128) - 1
+            hi: hexf64!("-0x1.c5041854df7d4p-3"),
+            lo: hexf64!("-0x1.797d4686c5393p-57"),
+        },
+        TwoFloat {
+            // exp(-31/128) - 1
+            hi: hexf64!("-0x1.b881a23aebb4ap-3"),
+            lo: hexf64!("0x1.5e3462e9ccc6ep-59"),
+        },
+        TwoFloat {
+            // exp(-30/128) - 1
+            hi: hexf64!("-0x1.abe60e1f21836p-3"),
+            lo: hexf64!("-0x1.6f8b82e653e2dp-60"),
+        },
+        TwoFloat {
+            // exp(-29/128) - 1
+            hi: hexf64!("-0x1.9f3129931faafp-3"),
+            lo: hexf64!("-0x1.00136f85b612cp-59"),
+        },
+        TwoFloat {
+            // exp(-28/128) - 1
+            hi: hexf64!("-0x1.9262c1c3430a1p-3"),
+            lo: hexf64!("-0x1.46ff6ec4a4251p-57"),
+        },
+        TwoFloat {
+            // exp(-27/128) - 1
+            hi: hexf64!("-0x1.857aa375db4e2p-3"),
+            lo: hexf64!("-0x1.960d6ed0eefd4p-58"),
+        },
+        TwoFloat {
+            // exp(-26/128) - 1
+            hi: hexf64!("-0x1.78789b0a5e0c0p-3"),
+            lo: hexf64!("0x1.e3a6bdaece8f9p-58"),
+        },
+        TwoFloat {
+            // exp(-25/128) - 1
+            hi: hexf64!("-0x1.6b5c7478983dap-3"),
+            lo: hexf64!("0x1.286a8f9e96160p-58"),
+        },
+        TwoFloat {
+            // exp(-24/128) - 1
+            hi: hexf64!("-0x1.5e25fb4fde211p-3"),
+            lo: hexf64!("0x1.64eec82915df3p-63"),
+        },
+        TwoFloat {
+            // exp(-23/128) - 1
+            hi: hexf64!("-0x1.50d4fab639757p-3"),
+            lo: hexf64!("-0x1.3bc197e5f2a7ep-59"),
+        },
+        TwoFloat {
+            // exp(-22/128) - 1
+            hi: hexf64!("-0x1.43693d679612dp-3"),
+            lo: hexf64!("-0x1.9da94a869862ap-57"),
+        },
+        TwoFloat {
+            // exp(-21/128) - 1
+            hi: hexf64!("-0x1.35e28db4ecd9bp-3"),
+            lo: hexf64!("-0x1.a2252f7d4b5f6p-58"),
+        },
+        TwoFloat {
+            // exp(-20/128) - 1
+            hi: hexf64!("-0x1.2840b5836cf67p-3"),
+            lo: hexf64!("-0x1.85405051eb425p-57"),
+        },
+        TwoFloat {
+            // exp(-19/128) - 1
+            hi: hexf64!("-0x1.1a837e4ba3760p-3"),
+            lo: hexf64!("0x1.a94ad2c8fa0bfp-58"),
+        },
+        TwoFloat {
+            // exp(-18/128) - 1
+            hi: hexf64!("-0x1.0caab118a1278p-3"),
+            lo: hexf64!("0x1.6ad4c353465b0p-61"),
+        },
+        TwoFloat {
+            // exp(-17/128) - 1
+            hi: hexf64!("-0x1.fd6c2d0e3d912p-4"),
+            lo: hexf64!("0x1.d117a3c69926cp-58"),
+        },
+        TwoFloat {
+            // exp(-16/128) - 1
+            hi: hexf64!("-0x1.e14aed893eef4p-4"),
+            lo: hexf64!("0x1.e1f58934f97afp-59"),
+        },
+        TwoFloat {
+            // exp(-15/128) - 1
+            hi: hexf64!("-0x1.c4f1331d22d3cp-4"),
+            lo: hexf64!("-0x1.ece0aa18a07e5p-63"),
+        },
+        TwoFloat {
+            // exp(-14/128) - 1
+            hi: hexf64!("-0x1.a85e8c62d9c13p-4"),
+            lo: hexf64!("-0x1.adf7745e77188p-58"),
+        },
+        TwoFloat {
+            // exp(-13/128) - 1
+            hi: hexf64!("-0x1.8b92870fa2b59p-4"),
+            lo: hexf64!("-0x1.ffa6c0b097a6bp-58"),
+        },
+        TwoFloat {
+            // exp(-12/128) - 1
+            hi: hexf64!("-0x1.6e8caff341feap-4"),
+            lo: hexf64!("-0x1.9573ded7888b2p-58"),
+        },
+        TwoFloat {
+            // exp(-11/128) - 1
+            hi: hexf64!("-0x1.514c92f634786p-4"),
+            lo: hexf64!("-0x1.64c069cd0a314p-58"),
+        },
+        TwoFloat {
+            // exp(-10/128) - 1
+            hi: hexf64!("-0x1.33d1bb17df2e7p-4"),
+            lo: hexf64!("-0x1.e19c873b1d6a8p-59"),
+        },
+        TwoFloat {
+            // exp(-9/128) - 1
+            hi: hexf64!("-0x1.161bb26cbb590p-4"),
+            lo: hexf64!("-0x1.589321a7ef10bp-60"),
+        },
+        TwoFloat {
+            // exp(-8/128) - 1
+            hi: hexf64!("-0x1.f0540438fd5c3p-5"),
+            lo: hexf64!("-0x1.a1ce01f9f6ca7p-61"),
+        },
+        TwoFloat {
+            // exp(-7/128) - 1
+            hi: hexf64!("-0x1.b3f864c07fffbp-5"),
+            lo: hexf64!("0x1.cfbc1f5774ea7p-61"),
+        },
+        TwoFloat {
+            // exp(-6/128) - 1
+            hi: hexf64!("-0x1.7723950130405p-5"),
+            lo: hexf64!("0x1.c677ad8fa478dp-61"),
+        },
+        TwoFloat {
+            // exp(-5/128) - 1
+            hi: hexf64!("-0x1.39d4a1a77e051p-5"),
+            lo: hexf64!("0x1.ee8939ec858d8p-59"),
+        },
+        TwoFloat {
+            // exp(-4/128) - 1
+            hi: hexf64!("-0x1.f8152aee9450ep-6"),
+            lo: hexf64!("0x1.4b00abf977627p-61"),
+        },
+        TwoFloat {
+            // exp(-3/128) - 1
+            hi: hexf64!("-0x1.7b88f290230dep-6"),
+            lo: hexf64!("0x1.e93d61cf69296p-60"),
+        },
+        TwoFloat {
+            // exp(-2/128) - 1
+            hi: hexf64!("-0x1.fc055004416dbp-7"),
+            lo: hexf64!("-0x1.82ef422ab152ap-61"),
+        },
+        TwoFloat {
+            // exp(-1/128) - 1
+            hi: hexf64!("-0x1.fe0154aaeed83p-8"),
+            lo: hexf64!("-0x1.00681d99aceefp-62"),
+        },
+        TwoFloat {
+            // exp(0/128) - 1
+            hi: hexf64!("0x0.0p+0"),
+            lo: hexf64!("0x0.0p+0"),
+        },
+        TwoFloat {
+            // exp(1/128) - 1
+            hi: hexf64!("0x1.0100ab00222d8p-7"),
+            lo: hexf64!("0x1.864c70578e6d1p-61"),
+        },
+        TwoFloat {
+            // exp(2/128) - 1
+            hi: hexf64!("0x1.0202ad5778e46p-6"),
+            lo: hexf64!("-0x1.51e6d305beec6p-62"),
+        },
+        TwoFloat {
+            // exp(3/128) - 1
+            hi: hexf64!("0x1.84890d9043745p-6"),
+            lo: hexf64!("0x1.cacb3aebd2b6fp-61"),
+        },
+        TwoFloat {
+            // exp(4/128) - 1
+            hi: hexf64!("0x1.040ac0224fd93p-5"),
+            lo: hexf64!("0x1.c17a107575019p-61"),
+        },
+        TwoFloat {
+            // exp(5/128) - 1
+            hi: hexf64!("0x1.465509d383eb0p-5"),
+            lo: hexf64!("0x1.45cc1cf959b1bp-60"),
+        },
+        TwoFloat {
+            // exp(6/128) - 1
+            hi: hexf64!("0x1.89246d053d178p-5"),
+            lo: hexf64!("0x1.4967f31eb2595p-59"),
+        },
+        TwoFloat {
+            // exp(7/128) - 1
+            hi: hexf64!("0x1.cc79f4f5613a3p-5"),
+            lo: hexf64!("-0x1.9b7d9052797c8p-61"),
+        },
+        TwoFloat {
+            // exp(8/128) - 1
+            hi: hexf64!("0x1.082b577d34ed8p-4"),
+            lo: hexf64!("-0x1.5272ff30eed1bp-59"),
+        },
+        TwoFloat {
+            // exp(9/128) - 1
+            hi: hexf64!("0x1.2a5dd543ccc4ep-4"),
+            lo: hexf64!("-0x1.280f19dace1bep-59"),
+        },
+        TwoFloat {
+            // exp(10/128) - 1
+            hi: hexf64!("0x1.4cd4fc989cd64p-4"),
+            lo: hexf64!("0x1.557a8671b89e7p-58"),
+        },
+        TwoFloat {
+            // exp(11/128) - 1
+            hi: hexf64!("0x1.6f91575870693p-4"),
+            lo: hexf64!("-0x1.b71235569f4d4p-61"),
+        },
+        TwoFloat {
+            // exp(12/128) - 1
+            hi: hexf64!("0x1.92937074e0cd7p-4"),
+            lo: hexf64!("-0x1.db0b9cc915fc5p-58"),
+        },
+        TwoFloat {
+            // exp(13/128) - 1
+            hi: hexf64!("0x1.b5dbd3f681223p-4"),
+            lo: hexf64!("0x1.f5c92a5200eeep-63"),
+        },
+        TwoFloat {
+            // exp(14/128) - 1
+            hi: hexf64!("0x1.d96b0eff0e794p-4"),
+            lo: hexf64!("-0x1.75385b2cdf93dp-59"),
+        },
+        TwoFloat {
+            // exp(15/128) - 1
+            hi: hexf64!("0x1.fd41afcba45e7p-4"),
+            lo: hexf64!("-0x1.2db6f4bbe33b4p-60"),
+        },
+        TwoFloat {
+            // exp(16/128) - 1
+            hi: hexf64!("0x1.10b022db7ae68p-3"),
+            lo: hexf64!("-0x1.8c4a5df1ec7e5p-58"),
+        },
+        TwoFloat {
+            // exp(17/128) - 1
+            hi: hexf64!("0x1.22e3b09dc54d8p-3"),
+            lo: hexf64!("-0x1.bd4b1c37ea8a2p-57"),
+        },
+        TwoFloat {
+            // exp(18/128) - 1
+            hi: hexf64!("0x1.353bc9fb00b21p-3"),
+            lo: hexf64!("0x1.6bae618011342p-57"),
+        },
+        TwoFloat {
+            // exp(19/128) - 1
+            hi: hexf64!("0x1.47b8b853aafecp-3"),
+            lo: hexf64!("-0x1.4c26602c63fdap-57"),
+        },
+        TwoFloat {
+            // exp(20/128) - 1
+            hi: hexf64!("0x1.5a5ac59b963cbp-3"),
+            lo: hexf64!("-0x1.fd91307e74c50p-57"),
+        },
+        TwoFloat {
+            // exp(21/128) - 1
+            hi: hexf64!("0x1.6d223c5b1063ap-3"),
+            lo: hexf64!("-0x1.4aae273c07a5ep-60"),
+        },
+        TwoFloat {
+            // exp(22/128) - 1
+            hi: hexf64!("0x1.800f67b00d7b8p-3"),
+            lo: hexf64!("0x1.7ab912c69ffebp-61"),
+        },
+        TwoFloat {
+            // exp(23/128) - 1
+            hi: hexf64!("0x1.9322934f54148p-3"),
+            lo: hexf64!("-0x1.b3564bc0ec9cdp-58"),
+        },
+        TwoFloat {
+            // exp(24/128) - 1
+            hi: hexf64!("0x1.a65c0b85ac1a9p-3"),
+            lo: hexf64!("0x1.a9c189196f8cdp-57"),
+        },
+        TwoFloat {
+            // exp(25/128) - 1
+            hi: hexf64!("0x1.b9bc1d3910092p-3"),
+            lo: hexf64!("0x1.ea39cb4039031p-57"),
+        },
+        TwoFloat {
+            // exp(26/128) - 1
+            hi: hexf64!("0x1.cd4315e9e0833p-3"),
+            lo: hexf64!("-0x1.172c31a1781f1p-61"),
+        },
+        TwoFloat {
+            // exp(27/128) - 1
+            hi: hexf64!("0x1.e0f143b41a554p-3"),
+            lo: hexf64!("-0x1.6e7fb859d5055p-62"),
+        },
+        TwoFloat {
+            // exp(28/128) - 1
+            hi: hexf64!("0x1.f4c6f5508ee5dp-3"),
+            lo: hexf64!("0x1.46ef7b808180ap-57"),
+        },
+        TwoFloat {
+            // exp(29/128) - 1
+            hi: hexf64!("0x1.04623d0b0f8c8p-2"),
+            lo: hexf64!("0x1.e17611afc42c5p-57"),
+        },
+        TwoFloat {
+            // exp(30/128) - 1
+            hi: hexf64!("0x1.0e7510fd7c564p-2"),
+            lo: hexf64!("-0x1.1c5b2e8735a43p-56"),
+        },
+        TwoFloat {
+            // exp(31/128) - 1
+            hi: hexf64!("0x1.189c1ecaeb083p-2"),
+            lo: hexf64!("0x1.b403d8c766006p-56"),
+        },
+        TwoFloat {
+            // exp(32/128) - 1
+            hi: hexf64!("0x1.22d78f0fa061ap-2"),
+            lo: hexf64!("-0x1.89843c4964554p-56"),
+        },
+    ];
+
+    EXPM1_128TH[(n + 32) as usize]
+}
+
+/// Compute exp(1/2)^n with n = 32*a + b
+///
+/// exp(1/2)^n = exp(32/2)^a * exp(1/2)^b
+///
+/// In order to have the exact result we can store the coefficeints
+/// for different values of `a` and `b`
+///
+/// with :
+///  - `|a| < 45`
+///  - `|b| < 32`
+///
+/// We obtain valid expression for `|n| < 32 * 45 = 1440`
+fn exp_half(n: i32) -> TwoFloat {
+    assert!(n < 1440, "exp_half max exponent is 1439: {}", n);
+
+    const EXP_HALF_N: [TwoFloat; 31] = [
+        TwoFloat {
+            // exp(1/2)^1
+            hi: hexf64!("0x1.a61298e1e069cp+0"),
+            lo: hexf64!("-0x1.b4690082a4906p-55"),
+        },
+        TwoFloat {
+            // exp(1/2)^2
+            hi: hexf64!("0x1.5bf0a8b145769p+1"),
+            lo: hexf64!("0x1.4d57ee2b1013ap-53"),
+        },
+        TwoFloat {
+            // exp(1/2)^3
+            hi: hexf64!("0x1.1ed3fe64fc541p+2"),
+            lo: hexf64!("0x1.5f6e4658d43eap-52"),
+        },
+        TwoFloat {
+            // exp(1/2)^4
+            hi: hexf64!("0x1.d8e64b8d4ddaep+2"),
+            lo: hexf64!("-0x1.9e62e22efca4cp-53"),
+        },
+        TwoFloat {
+            // exp(1/2)^5
+            hi: hexf64!("0x1.85d6fd931e0bbp+3"),
+            lo: hexf64!("0x1.d4dec34de84a0p-53"),
+        },
+        TwoFloat {
+            // exp(1/2)^6
+            hi: hexf64!("0x1.415e5bf6fb106p+4"),
+            lo: hexf64!("-0x1.a568407591768p-53"),
+        },
+        TwoFloat {
+            // exp(1/2)^7
+            hi: hexf64!("0x1.08ec721396bdbp+5"),
+            lo: hexf64!("0x1.4354c26b2875ep-49"),
+        },
+        TwoFloat {
+            // exp(1/2)^8
+            hi: hexf64!("0x1.b4c902e273a58p+5"),
+            lo: hexf64!("0x1.9e35b4eff6e4fp-49"),
+        },
+        TwoFloat {
+            // exp(1/2)^9
+            hi: hexf64!("0x1.68118ade1deaap+6"),
+            lo: hexf64!("0x1.6f9d8bafaba87p-49"),
+        },
+        TwoFloat {
+            // exp(1/2)^10
+            hi: hexf64!("0x1.28d389970338fp+7"),
+            lo: hexf64!("0x1.f66faad9235acp-49"),
+        },
+        TwoFloat {
+            // exp(1/2)^11
+            hi: hexf64!("0x1.e96244f21bbf6p+7"),
+            lo: hexf64!("0x1.298c834010b39p-48"),
+        },
+        TwoFloat {
+            // exp(1/2)^12
+            hi: hexf64!("0x1.936dc5690c08fp+8"),
+            lo: hexf64!("0x1.bd4d728fcb999p-47"),
+        },
+        TwoFloat {
+            // exp(1/2)^13
+            hi: hexf64!("0x1.4c92210816c89p+9"),
+            lo: hexf64!("0x1.0d5b86bb2485cp-45"),
+        },
+        TwoFloat {
+            // exp(1/2)^14
+            hi: hexf64!("0x1.122885aaeddaap+10"),
+            lo: hexf64!("0x1.bc7e802a24decp-44"),
+        },
+        TwoFloat {
+            // exp(1/2)^15
+            hi: hexf64!("0x1.c402b6eb1f6adp+10"),
+            lo: hexf64!("0x1.49c5fd40401f0p-45"),
+        },
+        TwoFloat {
+            // exp(1/2)^16
+            hi: hexf64!("0x1.749ea7d470c6ep+11"),
+            lo: hexf64!("-0x1.e83fe3ef6afd4p-46"),
+        },
+        TwoFloat {
+            // exp(1/2)^17
+            hi: hexf64!("0x1.332c4d2b7c4a1p+12"),
+            lo: hexf64!("0x1.877bfc89a825ep-46"),
+        },
+        TwoFloat {
+            // exp(1/2)^18
+            hi: hexf64!("0x1.fa7157c470f82p+12"),
+            lo: hexf64!("-0x1.e4d50f21f5ac5p-43"),
+        },
+        TwoFloat {
+            // exp(1/2)^19
+            hi: hexf64!("0x1.a17dd08c11dc1p+13"),
+            lo: hexf64!("-0x1.de54a23f86061p-41"),
+        },
+        TwoFloat {
+            // exp(1/2)^20
+            hi: hexf64!("0x1.5829dcf950560p+14"),
+            lo: hexf64!("-0x1.83e055cfea4bbp-40"),
+        },
+        TwoFloat {
+            // exp(1/2)^21
+            hi: hexf64!("0x1.1bb7015e84d3bp+15"),
+            lo: hexf64!("0x1.bc1c4193bcdb9p-40"),
+        },
+        TwoFloat {
+            // exp(1/2)^22
+            hi: hexf64!("0x1.d3c4488ee4f7fp+15"),
+            lo: hexf64!("0x1.f7b8937dac77dp-40"),
+        },
+        TwoFloat {
+            // exp(1/2)^23
+            hi: hexf64!("0x1.819bc560f6113p+16"),
+            lo: hexf64!("0x1.ab5fcbf2b9216p-39"),
+        },
+        TwoFloat {
+            // exp(1/2)^24
+            hi: hexf64!("0x1.3de1654d37c9ap+17"),
+            lo: hexf64!("0x1.75002e232b908p-38"),
+        },
+        TwoFloat {
+            // exp(1/2)^25
+            hi: hexf64!("0x1.060c52565ba66p+18"),
+            lo: hexf64!("-0x1.607621f784efep-36"),
+        },
+        TwoFloat {
+            // exp(1/2)^26
+            hi: hexf64!("0x1.b00b5916ac955p+18"),
+            lo: hexf64!("0x1.aa63a6c655d68p-37"),
+        },
+        TwoFloat {
+            // exp(1/2)^27
+            hi: hexf64!("0x1.64290bd5cad8bp+19"),
+            lo: hexf64!("0x1.c4da08cc70404p-35"),
+        },
+        TwoFloat {
+            // exp(1/2)^28
+            hi: hexf64!("0x1.259ac48bf05d7p+20"),
+            lo: hexf64!("-0x1.07e45cbbee1cfp-36"),
+        },
+        TwoFloat {
+            // exp(1/2)^29
+            hi: hexf64!("0x1.e4127437732b7p+20"),
+            lo: hexf64!("0x1.f4a21b9a4afd1p-36"),
+        },
+        TwoFloat {
+            // exp(1/2)^30
+            hi: hexf64!("0x1.8f0ccafad2a87p+21"),
+            lo: hexf64!("-0x1.0e8d00e46995ap-35"),
+        },
+        TwoFloat {
+            // exp(1/2)^31
+            hi: hexf64!("0x1.48f609e7b6bbep+22"),
+            lo: hexf64!("0x1.c297debcbca60p-32"),
+        },
+    ];
+    const EXP_16_N: [TwoFloat; 44] = [
+        TwoFloat {
+            // exp(16)^1
+            hi: hexf64!("0x1.0f2ebd0a80020p+23"),
+            lo: hexf64!("0x1.2488fc5c220adp-31"),
+        },
+        TwoFloat {
+            // exp(16)^2
+            hi: hexf64!("0x1.1f43fcc4b662cp+46"),
+            lo: hexf64!("0x1.f611e21006108p-8"),
+        },
+        TwoFloat {
+            // exp(16)^3
+            hi: hexf64!("0x1.304d6aeca254bp+69"),
+            lo: hexf64!("0x1.d7a5e2eb149ebp+14"),
+        },
+        TwoFloat {
+            // exp(16)^4
+            hi: hexf64!("0x1.425982cf597cdp+92"),
+            lo: hexf64!("0x1.02e71eada76d8p+37"),
+        },
+        TwoFloat {
+            // exp(16)^5
+            hi: hexf64!("0x1.55779b984f3ebp+115"),
+            lo: hexf64!("0x1.e45281da54712p+60"),
+        },
+        TwoFloat {
+            // exp(16)^6
+            hi: hexf64!("0x1.69b7f55b808bap+138"),
+            lo: hexf64!("0x1.6f21a89b844aep+83"),
+        },
+        TwoFloat {
+            // exp(16)^7
+            hi: hexf64!("0x1.7f2bc6e599b7ep+161"),
+            lo: hexf64!("0x1.46d9358056eb4p+106"),
+        },
+        TwoFloat {
+            // exp(16)^8
+            hi: hexf64!("0x1.95e54c5dd4217p+184"),
+            lo: hexf64!("0x1.fd4fd3548677cp+130"),
+        },
+        TwoFloat {
+            // exp(16)^9
+            hi: hexf64!("0x1.adf7d6c5fbb7ap+207"),
+            lo: hexf64!("0x1.9ffe2ce2ba6cdp+153"),
+        },
+        TwoFloat {
+            // exp(16)^10
+            hi: hexf64!("0x1.c777dc65c9488p+230"),
+            lo: hexf64!("0x1.d3ccd78123ba5p+174"),
+        },
+        TwoFloat {
+            // exp(16)^11
+            hi: hexf64!("0x1.e27b0a2f86833p+253"),
+            lo: hexf64!("0x1.a7b6e2b8658a4p+198"),
+        },
+        TwoFloat {
+            // exp(16)^12
+            hi: hexf64!("0x1.ff18562cc483ep+276"),
+            lo: hexf64!("-0x1.233168c763a20p+221"),
+        },
+        TwoFloat {
+            // exp(16)^13
+            hi: hexf64!("0x1.0eb40981671acp+300"),
+            lo: hexf64!("0x1.29640bb156506p+245"),
+        },
+        TwoFloat {
+            // exp(16)^14
+            hi: hexf64!("0x1.1ec2024fb6cefp+323"),
+            lo: hexf64!("-0x1.9422d9c2347aep+269"),
+        },
+        TwoFloat {
+            // exp(16)^15
+            hi: hexf64!("0x1.2fc3bb0fcb841p+346"),
+            lo: hexf64!("0x1.db4ee23db7cd6p+292"),
+        },
+        TwoFloat {
+            // exp(16)^16
+            hi: hexf64!("0x1.41c7a8814bebap+369"),
+            lo: hexf64!("0x1.c646601eeefb5p+312"),
+        },
+        TwoFloat {
+            // exp(16)^17
+            hi: hexf64!("0x1.54dd1adec0b48p+392"),
+            lo: hexf64!("-0x1.2bfc53615f0fep+338"),
+        },
+        TwoFloat {
+            // exp(16)^18
+            hi: hexf64!("0x1.69144ae1d9f07p+415"),
+            lo: hexf64!("-0x1.67d8bf9f3dd53p+360"),
+        },
+        TwoFloat {
+            // exp(16)^19
+            hi: hexf64!("0x1.7e7e678d54eb5p+438"),
+            lo: hexf64!("0x1.63ae7d736556cp+384"),
+        },
+        TwoFloat {
+            // exp(16)^20
+            hi: hexf64!("0x1.952da4c83af00p+461"),
+            lo: hexf64!("-0x1.aad695063fc20p+406"),
+        },
+        TwoFloat {
+            // exp(16)^21
+            hi: hexf64!("0x1.ad354ad6e368fp+484"),
+            lo: hexf64!("-0x1.45d9910503235p+430"),
+        },
+        TwoFloat {
+            // exp(16)^22
+            hi: hexf64!("0x1.c6a9c6bee04c8p+507"),
+            lo: hexf64!("0x1.d3ea517425318p+453"),
+        },
+        TwoFloat {
+            // exp(16)^23
+            hi: hexf64!("0x1.e1a0bba3c3728p+530"),
+            lo: hexf64!("-0x1.c8f9ccce05e3ap+476"),
+        },
+        TwoFloat {
+            // exp(16)^24
+            hi: hexf64!("0x1.fe31152b7ef6bp+553"),
+            lo: hexf64!("0x1.e0a8b9fec7ecep+497"),
+        },
+        TwoFloat {
+            // exp(16)^25
+            hi: hexf64!("0x1.0e398d7d01704p+577"),
+            lo: hexf64!("-0x1.1b8649000ffedp+523"),
+        },
+        TwoFloat {
+            // exp(16)^26
+            hi: hexf64!("0x1.1e4042aa53cfdp+600"),
+            lo: hexf64!("-0x1.73ca574593c91p+546"),
+        },
+        TwoFloat {
+            // exp(16)^27
+            hi: hexf64!("0x1.2f3a497f7830cp+623"),
+            lo: hexf64!("0x1.ece7bf7bd12b2p+568"),
+        },
+        TwoFloat {
+            // exp(16)^28
+            hi: hexf64!("0x1.413610319d4ccp+646"),
+            lo: hexf64!("-0x1.250de9eb0fea2p+592"),
+        },
+        TwoFloat {
+            // exp(16)^29
+            hi: hexf64!("0x1.5442e00d851d5p+669"),
+            lo: hexf64!("0x1.83b70a56057f9p+613"),
+        },
+        TwoFloat {
+            // exp(16)^30
+            hi: hexf64!("0x1.6870ea75e682dp+692"),
+            lo: hexf64!("-0x1.034729ffdd0d6p+636"),
+        },
+        TwoFloat {
+            // exp(16)^31
+            hi: hexf64!("0x1.7dd156a715f16p+715"),
+            lo: hexf64!("0x1.3d26f623c56bcp+661"),
+        },
+        TwoFloat {
+            // exp(16)^32
+            hi: hexf64!("0x1.9476504ba852ep+738"),
+            lo: hexf64!("0x1.b0272159f0071p+684"),
+        },
+        TwoFloat {
+            // exp(16)^33
+            hi: hexf64!("0x1.ac7316ee74ed5p+761"),
+            lo: hexf64!("0x1.ec158afbf5767p+707"),
+        },
+        TwoFloat {
+            // exp(16)^34
+            hi: hexf64!("0x1.c5dc0e57174a2p+784"),
+            lo: hexf64!("0x1.0813267d07b90p+725"),
+        },
+        TwoFloat {
+            // exp(16)^35
+            hi: hexf64!("0x1.e0c6cfded96e2p+807"),
+            lo: hexf64!("-0x1.0a3b12a7dd3dep+752"),
+        },
+        TwoFloat {
+            // exp(16)^36
+            hi: hexf64!("0x1.fd4a3cccc1d98p+830"),
+            lo: hexf64!("-0x1.4f3870d0b9535p+776"),
+        },
+        TwoFloat {
+            // exp(16)^37
+            hi: hexf64!("0x1.0dbf48e430396p+854"),
+            lo: hexf64!("-0x1.31e09ef47fe9fp+799"),
+        },
+        TwoFloat {
+            // exp(16)^38
+            hi: hexf64!("0x1.1dbebdb9f1388p+877"),
+            lo: hexf64!("-0x1.94b9c8dfe4ecdp+823"),
+        },
+        TwoFloat {
+            // exp(16)^39
+            hi: hexf64!("0x1.2eb1161f782b7p+900"),
+            lo: hexf64!("0x1.858cc679c7d16p+843"),
+        },
+        TwoFloat {
+            // exp(16)^40
+            hi: hexf64!("0x1.40a4b9c27178ap+923"),
+            lo: hexf64!("-0x1.41d437e9132c2p+869"),
+        },
+        TwoFloat {
+            // exp(16)^41
+            hi: hexf64!("0x1.53a8eb04faf7cp+946"),
+            lo: hexf64!("0x1.7deea8bc3420dp+891"),
+        },
+        TwoFloat {
+            // exp(16)^42
+            hi: hexf64!("0x1.67cdd3f624846p+969"),
+            lo: hexf64!("-0x1.b2c19b09043f9p+913"),
+        },
+        TwoFloat {
+            // exp(16)^43
+            hi: hexf64!("0x1.7d24940f5e537p+992"),
+            lo: hexf64!("0x1.99a8f3ddc5edcp+933"),
+        },
+        TwoFloat {
+            // exp(16)^44
+            hi: hexf64!("0x1.93bf4ec282efbp+1015"),
+            lo: hexf64!("0x1.9052bfcd70170p+960"),
+        },
+    ];
+
+    // TODO: Check that the inversion doesn't lose precision
+    if n.is_negative() {
+        return 1.0 / exp_half(-n);
+    }
+
+    let (a, b) = ((n / 32) as usize, (n % 32) as usize);
+
+    match (a > 0, b > 0) {
+        (true, true) => EXP_16_N[a - 1] * EXP_HALF_N[b - 1],
+        (true, false) => EXP_16_N[a - 1],
+        (false, true) => EXP_HALF_N[b - 1],
+        (false, false) => 1.into(),
+    }
+}
+
 impl TwoFloat {
+    fn expm1_quarter(self) -> TwoFloat {
+        // We need to make sure that (1 + x) does not lose possible significant
+        // digits, so no matter what strategy we choose here, the convergence
+        // needs to go out to x = log(1.5) = 0.22. We have it work for until a
+        // quarter, because that's a nice round power of two.
+        assert!(self.hi().abs() <= 0.25);
+
+        // The idea is to use the identity
+        //
+        //   expm1(x) = expm1(x0) + exp(x0) * expm1(x - x0)
+        //
+        // to reduce the expansion order.
+        let n = libm::round(128.0 * self.hi());
+        let x0 = n / 128.0;
+        let y = self - x0;
+
+        let expm1_x0 = expm1_128th(libm::trunc(n) as i32);
+        let exp_x0 = expm1_x0 + 1.0;
+        let expm1_y = y * polynomial!(y, 1.0, FRAC_FACT[2..15]);
+        //return expm1_x0.add_small(exp_x0 * exp_y);
+        expm1_x0 + exp_x0 * expm1_y
+    }
+
     /// Returns `e^(self)`, (the exponential function).
+    ///
+    /// Computed by rewriting `self = y/2 +z` with `y` the rounded value of self.
+    /// From this we can rewrite the exponential function into `exp(sel) = exp(1/2)^y * exp(z)`.
+    /// The two exponential functions can now be computed by means of lookup table
+    /// and fast converging taylor series.
+    ///
+    /// (Shout-out to the author of  [libxprec](https://github.com/tuwien-cms/libxprec) for
+    /// pointing it out )
     ///
     /// # Examples
     ///
@@ -159,7 +935,7 @@ impl TwoFloat {
     /// let b = a.exp();
     /// let e2 = twofloat::consts::E * twofloat::consts::E;
     ///
-    /// assert!((b - e2).abs() / e2 < 1e-30);
+    /// assert!((b - e2).abs() / e2 < 1e-31);
     /// ```
     pub fn exp(self) -> Self {
         if self.hi <= EXP_LOWER_LIMIT {
@@ -172,57 +948,23 @@ impl TwoFloat {
         } else if self.hi == 0.0 {
             Self::from(1.0)
         } else {
-            // reduce value to range |n*r| <= ln(2)/2 ~ 0.347
-            // where self = k*ln(2) + n*r
-            // Therefore:
-            //    exp(self) = 2^k * exp(r)^n
-            // We can increase the value of `n` making the convergence of the
-            // remaining exponential function faster
+            // Compute the exponential of x = y/2 + z
+            // Where y = round(2*x) giving z <= 0.25
+            //
+            // exp( y/2 + z ) = exp(1/2)^y * exp(z)
+            //
+            // exp(1/2)^y : can be computed with lookup table for integer y
+            // exp(z) : can be computed using the value of exp_m1(z)
+            //          with another lookup table
 
-            let k = libm::trunc((FRAC_1_LN_2 * self).hi - 0.5);
-            // n = 512 is chosen;
-            let r = (self - LN_2 * k) / 512.0;
-            // TODO: Redefine EPSILON ?
-            let eps = Self::from(1e-32) / 512.0;
+            // x = y/2 + z
+            let y = libm::round(2.0 * self.hi());
+            let z = self - y / 2.0;
 
-            let x = r;
-            let mut p = x * x;
-            let mut r = x + p * 0.5;
-            // Step
-            p *= x;
-            let mut t = p * FRAC_FACT[3];
-            let mut i = 3;
-            loop {
-                r += t;
-                p *= x;
-                i += 1;
-                t = p * FRAC_FACT[i];
-                if i >= 20 || t.abs() <= eps {
-                    //dbg!(i, k);
-                    break;
-                }
-            }
-            r += 1.0 + t;
-
-            // Recover rescaling of r
-            r = r * r; // exp(r)^2
-            r = r * r; // exp(r)^4
-            r = r * r; // exp(r)^8
-            r = r * r; // exp(r)^16
-            r = r * r; // exp(r)^32
-            r = r * r; // exp(r)^64
-            r = r * r; // exp(r)^128
-            r = r * r; // exp(r)^256
-            r = r * r; // exp(r)^512
-
-            if k == 0.0 {
-                r
-            } else {
-                Self {
-                    hi: mul_pow2(r.hi, k as i32),
-                    lo: mul_pow2(r.lo, k as i32),
-                }
-            }
+            // exp(z + y/2) = (1 + expm1(z)) exp(1/2)^y
+            let exp_z = z.expm1_quarter() + 1.0;
+            let exp_y = exp_half(y as i32);
+            return exp_z * exp_y;
         }
     }
 
@@ -244,7 +986,7 @@ impl TwoFloat {
     /// let res = TwoFloat::try_from((9.5367477115374552e-07, -7.0551613072428143e-23)).unwrap();
     ///
     /// assert!(((b-res)/res) == 0.0);
-    /// assert!(((c-res)/res).abs() < 1e-22);
+    /// assert!(((c-res)/res).abs() < 1e-29);
     /// ```
     pub fn exp_m1(self) -> Self {
         if self < -LN_2 || self > LN_FRAC_3_2 {
@@ -276,7 +1018,7 @@ impl TwoFloat {
     ///
     /// assert!((a - res).abs() < 1e-29);
     /// assert!((b - res).abs() < 1e-31);
-    /// assert!((c - res).abs() < 1e-30);
+    /// assert!((c - res).abs() < 1e-31);
     /// ```
     pub fn exp2(self) -> Self {
         if self < -1074.0 {
@@ -324,7 +1066,7 @@ impl TwoFloat {
     ///
     /// ```
     /// let a = twofloat::consts::E.ln();
-    /// assert!((a - 1.0).abs() < 1e-29);
+    /// assert!((a - 1.0).abs() < 1e-31);
     /// ```
     pub fn ln(self) -> Self {
         if self == 1.0 {
@@ -373,11 +1115,14 @@ impl TwoFloat {
     ///
     /// # Examples
     ///
+    /// ```
+    /// # use twofloat::TwoFloat;
     /// let a = TwoFloat::from(81.0);
     /// let b = TwoFloat::from(3.0);
     /// let c = TwoFloat::log(a, b);
     ///
-    /// assert!((c - 4.0).abs() < 1e-12);
+    /// assert!((c - 4.0).abs()/4.0 < 1e-31);
+    /// ```
     pub fn log(self, base: Self) -> Self {
         self.ln() / base.ln()
     }

--- a/src/functions/explog.rs
+++ b/src/functions/explog.rs
@@ -159,7 +159,7 @@ impl TwoFloat {
     /// let b = a.exp();
     /// let e2 = twofloat::consts::E * twofloat::consts::E;
     ///
-    /// assert!((b - e2).abs() / e2 < 1e-16);
+    /// assert!((b - e2).abs() / e2 < 1e-30);
     /// ```
     pub fn exp(self) -> Self {
         if self.hi <= EXP_LOWER_LIMIT {
@@ -393,7 +393,7 @@ impl TwoFloat {
     /// # use twofloat::TwoFloat;
     /// let a = TwoFloat::from(64.0).log2();
     ///
-    /// assert!((a - 6.0).abs() < 1e-12, "{}", a);
+    /// assert!(a - 6.0 == 0.0, "{}", a);
     /// ```
     pub fn log2(self) -> Self {
         if self == 1.0 {
@@ -417,8 +417,7 @@ impl TwoFloat {
     /// ```
     /// # use twofloat::TwoFloat;
     /// let a = TwoFloat::from(100.0).log10();
-    ///
-    /// assert!((a - 2.0).abs() < 1e-12);
+    /// assert!((a - 2.0).abs() < 1e-30, "{}", a);
     /// ```
     pub fn log10(self) -> Self {
         self.ln() / LN_10

--- a/src/functions/explog.rs
+++ b/src/functions/explog.rs
@@ -163,6 +163,114 @@ const EXP2_COEFFS: [TwoFloat; 14] = [
     },
 ];
 
+const FRAC_FACT: [TwoFloat; 21] = [
+    TwoFloat {
+        // 1/0!
+        hi: hexf64!("0x1.0000000000000p+0"),
+        lo: hexf64!("0x0.0p+0"),
+    },
+    TwoFloat {
+        // 1/1!
+        hi: hexf64!("0x1.0000000000000p+0"),
+        lo: hexf64!("0x0.0p+0"),
+    },
+    TwoFloat {
+        // 1/2!
+        hi: hexf64!("0x1.0000000000000p-1"),
+        lo: hexf64!("0x0.0p+0"),
+    },
+    TwoFloat {
+        // 1/3!
+        hi: hexf64!("0x1.5555555555555p-3"),
+        lo: hexf64!("0x1.5555555555555p-57"),
+    },
+    TwoFloat {
+        // 1/4!
+        hi: hexf64!("0x1.5555555555555p-5"),
+        lo: hexf64!("0x1.5555555555555p-59"),
+    },
+    TwoFloat {
+        // 1/5!
+        hi: hexf64!("0x1.1111111111111p-7"),
+        lo: hexf64!("0x1.1111111111111p-63"),
+    },
+    TwoFloat {
+        // 1/6!
+        hi: hexf64!("0x1.6c16c16c16c17p-10"),
+        lo: hexf64!("-0x1.f49f49f49f49fp-65"),
+    },
+    TwoFloat {
+        // 1/7!
+        hi: hexf64!("0x1.a01a01a01a01ap-13"),
+        lo: hexf64!("0x1.a01a01a01a01ap-73"),
+    },
+    TwoFloat {
+        // 1/8!
+        hi: hexf64!("0x1.a01a01a01a01ap-16"),
+        lo: hexf64!("0x1.a01a01a01a01ap-76"),
+    },
+    TwoFloat {
+        // 1/9!
+        hi: hexf64!("0x1.71de3a556c734p-19"),
+        lo: hexf64!("-0x1.c154f8ddc6c00p-73"),
+    },
+    TwoFloat {
+        // 1/10!
+        hi: hexf64!("0x1.27e4fb7789f5cp-22"),
+        lo: hexf64!("0x1.cbbc05b4fa99ap-76"),
+    },
+    TwoFloat {
+        // 1/11!
+        hi: hexf64!("0x1.ae64567f544e4p-26"),
+        lo: hexf64!("-0x1.c062e06d1f209p-80"),
+    },
+    TwoFloat {
+        // 1/12!
+        hi: hexf64!("0x1.1eed8eff8d898p-29"),
+        lo: hexf64!("-0x1.2aec959e14c06p-83"),
+    },
+    TwoFloat {
+        // 1/13!
+        hi: hexf64!("0x1.6124613a86d09p-33"),
+        lo: hexf64!("0x1.f28e0cc748ebep-87"),
+    },
+    TwoFloat {
+        // 1/14!
+        hi: hexf64!("0x1.93974a8c07c9dp-37"),
+        lo: hexf64!("0x1.05d6f8a2efd1fp-92"),
+    },
+    TwoFloat {
+        // 1/15!
+        hi: hexf64!("0x1.ae7f3e733b81fp-41"),
+        lo: hexf64!("0x1.1d8656b0ee8cbp-97"),
+    },
+    TwoFloat {
+        // 1/16!
+        hi: hexf64!("0x1.ae7f3e733b81fp-45"),
+        lo: hexf64!("0x1.1d8656b0ee8cbp-101"),
+    },
+    TwoFloat {
+        // 1/17!
+        hi: hexf64!("0x1.952c77030ad4ap-49"),
+        lo: hexf64!("0x1.ac981465ddc6cp-103"),
+    },
+    TwoFloat {
+        // 1/18!
+        hi: hexf64!("0x1.6827863b97d97p-53"),
+        lo: hexf64!("0x1.eec01221a8b0bp-107"),
+    },
+    TwoFloat {
+        // 1/19!
+        hi: hexf64!("0x1.2f49b46814157p-57"),
+        lo: hexf64!("0x1.2650f61dbdcb4p-112"),
+    },
+    TwoFloat {
+        // 1/20!
+        hi: hexf64!("0x1.e542ba4020225p-62"),
+        lo: hexf64!("0x1.ea72b4afe3c2fp-120"),
+    },
+];
+
 fn mul_pow2(mut x: f64, mut y: i32) -> f64 {
     loop {
         if y < -1074 {
@@ -203,36 +311,55 @@ impl TwoFloat {
         } else if self.hi == 0.0 {
             Self::from(1.0)
         } else {
-            // reduce value to range |r| <= ln(2)/2
-            // where self = k*ln(2) + r
+            // reduce value to range |n*r| <= ln(2)/2 ~ 0.347
+            // where self = k*ln(2) + n*r
+            // Therefore:
+            //    exp(self) = 2^k * exp(r)^n
+            // We can increase the value of `n` making the convergence of the
+            // remaining exponential function faster
 
             let k = libm::trunc((FRAC_1_LN_2 * self).hi + 0.5);
-            let r = self - LN_2 * k;
+            // n = 512 is chosen;
+            let r = (self - LN_2 * k) / 512.0;
+            // TODO: Redefine EPSILON ?
+            let eps = Self::from(1e-32) / 512.0;
 
-            // Now approximate the function
-            //
-            // R(r^2) = r*(exp(r)+1)/(exp(r)-1) = 2 + P1*r^2 + P2*r^4 + ...
-            //
-            // using a polynomial obtained by the Remez algorithm on the
-            // interval [0, ln(2)/2], then:
-            //
-            // exp(r) = 1 + 2*r/(R-r) = 1 + r + (r*R1) / (2-R1)
-            //
-            // where R1 = r - (P1*r^2 + P2*r^4 + ...)
+            let x = r;
+            let mut p = x * x;
+            let mut r = x + p * 0.5;
+            // Step
+            p *= x;
+            let mut t = p * FRAC_FACT[3];
+            let mut i = 3;
+            loop {
+                r += t;
+                p *= x;
+                i += 1;
+                t = p * FRAC_FACT[i];
+                if i >= 20 || t.abs() <= eps {
+                    //dbg!(i, k);
+                    break;
+                }
+            }
+            r += 1.0 + t;
 
-            let rr = r * r;
-            let r1 = r - rr * polynomial!(rr, EXP_COEFFS);
-
-            let exp_r = 1.0 - ((r * r1) / (r1 - 2.0) - r);
-
-            // then scale back
+            // Recover rescaling of r
+            r = r * r; // exp(r)^2
+            r = r * r; // exp(r)^4
+            r = r * r; // exp(r)^8
+            r = r * r; // exp(r)^16
+            r = r * r; // exp(r)^32
+            r = r * r; // exp(r)^64
+            r = r * r; // exp(r)^128
+            r = r * r; // exp(r)^256
+            r = r * r; // exp(r)^512
 
             if k == 0.0 {
-                exp_r
+                r
             } else {
                 Self {
-                    hi: mul_pow2(exp_r.hi, k as i32),
-                    lo: mul_pow2(exp_r.lo, k as i32),
+                    hi: mul_pow2(r.hi, k as i32),
+                    lo: mul_pow2(r.lo, k as i32),
                 }
             }
         }

--- a/src/functions/explog.rs
+++ b/src/functions/explog.rs
@@ -24,34 +24,6 @@ const LN_FRAC_3_2: TwoFloat = TwoFloat {
 const EXP_UPPER_LIMIT: f64 = hexf64!("0x1.62e42fefa39efp9"); // ln(0x1.0p1024)
 const EXP_LOWER_LIMIT: f64 = hexf64!("-0x1.74385446d71c3p9"); // ln(0x1.0p-1074)
 
-// Coefficients for polynomial approximation of x*(exp(x)+1)/(exp(x)-1)
-const EXP_COEFFS: [TwoFloat; 6] = [
-    TwoFloat {
-        hi: hexf64!("0x1.5555555555555p-3"),
-        lo: hexf64!("0x1.32460411c87c6p-57"),
-    },
-    TwoFloat {
-        hi: hexf64!("-0x1.6c16c16c16af3p-9"),
-        lo: hexf64!("0x1.136a2c950fda6p-63"),
-    },
-    TwoFloat {
-        hi: hexf64!("0x1.1566abbf9f4f6p-14"),
-        lo: hexf64!("0x1.1110477bd284cp-68"),
-    },
-    TwoFloat {
-        hi: hexf64!("-0x1.bbd7768cb5288p-20"),
-        lo: hexf64!("0x1.fece87c086974p-76"),
-    },
-    TwoFloat {
-        hi: hexf64!("0x1.66a4e5c4c23f6p-25"),
-        lo: hexf64!("-0x1.c8771e6260e4bp-79"),
-    },
-    TwoFloat {
-        hi: hexf64!("-0x1.1f6dc1f8a9983p-30"),
-        lo: hexf64!("-0x1.d03ec3b33eaf5p-84"),
-    },
-];
-
 const EXP_M1_COEFFS: [TwoFloat; 12] = [
     TwoFloat {
         hi: hexf64!("0x1.0p-1"),

--- a/src/functions/explog.rs
+++ b/src/functions/explog.rs
@@ -250,8 +250,13 @@ impl TwoFloat {
         if self < -LN_2 || self > LN_FRAC_3_2 {
             self.exp() - 1.0
         } else {
-            let r = polynomial!(self, 1.0, FRAC_FACT[2..12]);
-            self * r
+            let x = self.abs();
+            let r = polynomial!(x, 1.0, FRAC_FACT[2..15]);
+            if self < 0.0 {
+                self * r * self.exp()
+            } else {
+                self * r
+            }
         }
     }
 
@@ -336,17 +341,16 @@ impl TwoFloat {
 
     /// Returns the natural logarithm of `1 + self`.
     ///
-    /// Uses Newton–Raphson iteration which depends on the `expm1` function,
-    /// so may not be fully accurate to the full precision of a `TwoFloat`.
+    /// Uses Newton–Raphson iteration which depends on the `expm1` function
     ///
     /// # Example
     ///
     /// ```
     /// # use twofloat::TwoFloat;
-    /// let a = TwoFloat::from(0.1);
+    /// let a = TwoFloat::from(-0.5);
     /// let b = a.ln_1p();
-    /// let c = 0.1f64.ln_1p();
-    /// assert!((b - c).abs() < 1e-10);
+    /// let c = -twofloat::consts::LN_2;//0.1f64.ln_1p();
+    /// assert!((b - c).abs() < 1e-29);
     /// ```
     pub fn ln_1p(self) -> Self {
         if self == 0.0 {

--- a/src/functions/explog.rs
+++ b/src/functions/explog.rs
@@ -313,6 +313,7 @@ impl TwoFloat {
         } else {
             let mut x = Self::from(libm::log(self.hi));
             x += self * (-x).exp() - 1.0;
+            x += self * (-x).exp() - 1.0;
             x + self * (-x).exp() - 1.0
         }
     }

--- a/src/functions/explog.rs
+++ b/src/functions/explog.rs
@@ -24,7 +24,6 @@ const LN_FRAC_3_2: TwoFloat = TwoFloat {
 const EXP_UPPER_LIMIT: f64 = hexf64!("0x1.62e42fefa39efp9"); // ln(0x1.0p1024)
 const EXP_LOWER_LIMIT: f64 = hexf64!("-0x1.74385446d71c3p9"); // ln(0x1.0p-1074)
 
-
 // Coefficients for polynomial approximation of 2^x on [-0.5, 0.5]
 const EXP2_COEFFS: [TwoFloat; 14] = [
     TwoFloat {

--- a/tests/arithmetic_tests.rs
+++ b/tests/arithmetic_tests.rs
@@ -10,7 +10,10 @@ use twofloat::{no_overlap, TwoFloat};
 #[macro_use]
 pub mod common;
 
-use common::{get_twofloat, get_valid_pair, get_valid_twofloat, random_float, repeated_test};
+use common::{
+    get_twofloat, get_valid_ddouble, get_valid_pair, get_valid_twofloat, random_float,
+    repeated_test,
+};
 
 // Tests for construction from two f64 values
 
@@ -23,14 +26,14 @@ fn new_add_test() {
 
         assert!(
             result.is_valid(),
-            "Result of new_add({}, {}) was invalid",
+            "Result of new_add({:.e}, {:.e}) was invalid",
             a,
             b
         );
         assert_eq!(
             expected,
             result.hi(),
-            "Result of new_add({}, {}) had unexpected high word",
+            "Result of new_add({:.e}, {:.e}) had unexpected high word",
             a,
             b
         );
@@ -46,14 +49,14 @@ fn new_sub_test() {
 
         assert!(
             result.is_valid(),
-            "Result of new_sub({}, {}) was invalid",
+            "Result of new_sub({:.e}, {:.e}) was invalid",
             a,
             b
         );
         assert_eq!(
             expected,
             result.hi(),
-            "Result of new_sub({}, {}) had unexpected high word",
+            "Result of new_sub({:.e}, {:.e}) had unexpected high word",
             a,
             b
         );
@@ -68,14 +71,14 @@ fn new_mul_test() {
 
     assert!(
         result.is_valid(),
-        "Result of new_mul({}, {}) was invalid",
+        "Result of new_mul({:.e}, {:.e}) was invalid",
         a,
         b
     );
     assert_eq!(
         expected,
         result.hi(),
-        "Result of new_mul({}, {}) had unexpected high word",
+        "Result of new_mul({:.e}, {:.e}) had unexpected high word",
         a,
         b
     );
@@ -89,7 +92,7 @@ fn new_div_test() {
 
         assert!(
             result.is_valid(),
-            "Result of new_div({}, {}) was invalid",
+            "Result of new_div({:.e}, {:.e}) was invalid",
             a,
             b
         );
@@ -98,11 +101,42 @@ fn new_div_test() {
             result.hi(),
             a / b,
             10,
-            "Incorrect result of new_div({}, {})",
+            "Incorrect result of new_div({:.e}, {:.e})",
             a,
             b
         );
     });
+}
+
+#[test]
+fn div_precision_test() {
+    repeated_test(|| {
+        // Limit the exponent to be less then 1e16 away from the maximal exponent
+        // to allow a complete division
+        let expected = get_valid_ddouble(|x| x.hi().log10().abs() < 290.0);
+        let one: TwoFloat = 1.into();
+        // Use f64/TwoFloat
+        let result = 1.0 / (1.0 / expected);
+        let difference = ((result - expected) / expected).abs();
+        assert!(
+            difference < 1e-31,
+            "1/(1/a) != a (diff {}) ({:.e}, {:.e}) for f64/TwoFloat",
+            difference,
+            expected,
+            result,
+        );
+
+        // Use TwoFloat/TwoFloat
+        let result = one / (one / expected);
+        let difference = ((result - expected) / expected).abs();
+        assert!(
+            difference < 1e-31,
+            "1/(1/a) != a (diff {}) ({:.e}, {:.e}) for TwoFloat/TwoFloat",
+            difference,
+            expected,
+            result,
+        );
+    })
 }
 
 // Test for negation operator

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,7 @@ use twofloat::{TwoFloat, TwoFloatError};
 const TEST_ITERS: usize = 10000;
 
 #[cfg(not(all(target_arch = "aarch64", target_os = "linux")))]
-const TEST_ITERS: usize = 100000;
+const TEST_ITERS: usize = 100_000;
 
 pub fn random_float() -> f64 {
     let mut engine = rand::thread_rng();

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -146,7 +146,7 @@ where
 {
     loop {
         let a = random_ddouble();
-        if pred(a){
+        if pred(a) {
             return a;
         }
     }

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -24,6 +24,21 @@ pub fn random_float() -> f64 {
     }
 }
 
+pub fn random_ddouble() -> TwoFloat {
+    let mut rng = rand::thread_rng();
+    let mantissa_bits_hi: u64 =
+        (0..f64::MANTISSA_DIGITS).fold(0u64, |bits, n| bits + (rng.gen_range(0..=1) << n));
+    let mantissa_bits_lo: u64 =
+        (0..f64::MANTISSA_DIGITS).fold(0u64, |bits, n| bits + (rng.gen_range(0..=1) << n));
+    let exponent_bits: u64 = (0..11)
+        .fold(0u64, |bits, n| bits + (rng.gen_range(0..=1) << n))
+        .max(53);
+    let sgn: u64 = rng.gen_range(0..=1);
+    let x_hi = f64::from_bits(sgn << 63 | exponent_bits << 52 | mantissa_bits_hi);
+    let x_lo = f64::from_bits(sgn << 63 | (exponent_bits - 53) << 52 | mantissa_bits_lo);
+    TwoFloat::new_add(x_hi, x_lo)
+}
+
 pub fn repeated_test(mut test: impl FnMut()) {
     for _ in 0..TEST_ITERS {
         test();
@@ -121,6 +136,18 @@ where
         let b = random_float();
         if pred(a, b) {
             return (a, b);
+        }
+    }
+}
+
+pub fn get_valid_ddouble<F>(pred: F) -> TwoFloat
+where
+    F: Fn(TwoFloat) -> bool,
+{
+    loop {
+        let a = random_ddouble();
+        if pred(a){
+            return a;
         }
     }
 }

--- a/tests/explog_tests.rs
+++ b/tests/explog_tests.rs
@@ -4,16 +4,13 @@
 pub mod common;
 
 use common::*;
-use hexf::hexf64;
 use rand::Rng;
 use twofloat::TwoFloat;
-
-const EXP_UPPER_LIMIT: f64 = hexf64!("0x1.62e42fefa39efp9"); // ln(0x1.0p1024)
 
 #[test]
 fn exp_test() {
     let mut rng = rand::thread_rng();
-    let src_dist = rand::distributions::Uniform::new(-600.0, EXP_UPPER_LIMIT);
+    let src_dist = rand::distributions::Uniform::new(-600_f64, 600.0);
 
     repeated_test(|| {
         let a = rng.sample(src_dist);
@@ -27,8 +24,8 @@ fn exp_test() {
         let difference = ((exp_b - exp_a) / exp_a).abs();
 
         assert!(
-            difference < 1e-10,
-            "Mismatch in exp({}): {} vs {:?}",
+            difference < 1e-15,
+            "Mismatch in exp({}): {} vs {}",
             a,
             exp_a,
             exp_b
@@ -50,11 +47,11 @@ fn exp_m1_test() {
 
         assert!(exp_b.is_valid(), "exp_m1({}) produced invalid value", a);
 
-        let difference = exp_b - exp_a;
+        let difference = ((exp_b - exp_a) / exp_a).abs();
 
         assert!(
-            difference < 1e-10,
-            "Mismatch in exp({}): {} vs {:?}",
+            difference < 1e-14,
+            "Mismatch in exp({}): {:e} vs {}",
             a,
             exp_a,
             exp_b
@@ -65,7 +62,7 @@ fn exp_m1_test() {
 #[test]
 fn ln_test() {
     let mut rng = rand::thread_rng();
-    let src_dist = rand::distributions::Uniform::new(f64::from_bits(1u64), f64::MAX);
+    let src_dist = rand::distributions::Uniform::new(0f64, 1e300);
 
     repeated_test(|| {
         let a = rng.sample(src_dist);
@@ -74,13 +71,13 @@ fn ln_test() {
         let ln_a = a.ln();
         let ln_b = b.ln();
 
-        assert!(ln_b.is_valid(), "ln({}) produced invalid value", a);
+        assert!(ln_b.is_valid(), "ln({:e}) produced invalid value", a);
 
-        let difference = (ln_b - ln_a).abs();
+        let difference = ((ln_b - ln_a) / ln_a).abs();
 
         assert!(
-            difference < 1e-10,
-            "Mismatch in ln({}): {} vs {:?}",
+            difference < 1e-16,
+            "Mismatch in ln({:e}): {} vs {:?}",
             a,
             ln_a,
             ln_b
@@ -93,14 +90,14 @@ fn ln_negative_test() {
     repeated_test(|| {
         let a = get_valid_twofloat(|x, _| x < 0.0);
         let result = a.ln();
-        assert!(!result.is_valid(), "ln({:?}) produced a valid result", a);
+        assert!(!result.is_valid(), "ln({:e}) produced a valid result", a);
     })
 }
 
 #[test]
 fn ln_1p_test() {
     let mut rng = rand::thread_rng();
-    let src_dist = rand::distributions::Uniform::new(-1.0 + f64::EPSILON, f64::MAX);
+    let src_dist = rand::distributions::Uniform::new(-1.0f64, 1e300);
 
     repeated_test(|| {
         let a = rng.sample(src_dist);
@@ -109,16 +106,45 @@ fn ln_1p_test() {
         let ln_a = a.ln_1p();
         let ln_b = b.ln_1p();
 
-        assert!(ln_b.is_valid(), "ln({}) produced invalid value", a);
+        assert!(ln_b.is_valid(), "ln({:e}) produced invalid value", a);
 
-        let difference = (ln_b - ln_a).abs();
+        let difference = ((ln_b - ln_a) / ln_a).abs();
 
         assert!(
-            difference < 1e-10,
-            "Mismatch in ln({}): {} vs {:?}",
+            difference < 1e-16,
+            "Mismatch in ln({:e}): {} vs {:?}",
             a,
             ln_a,
             ln_b
+        );
+    });
+}
+
+#[test]
+fn exp_ln_test() {
+    let mut rng = rand::thread_rng();
+    let src_dist = rand::distributions::Uniform::new(-600.0, 600.0);
+
+    repeated_test(|| {
+        let expected = TwoFloat::from(rng.sample(src_dist));
+        println!("{:e}", expected);
+
+        let result = expected.exp().ln();
+
+        assert!(
+            result.is_valid(),
+            "ln(exp({})) produced invalid value",
+            expected
+        );
+
+        let difference = ((result - expected) / expected).abs();
+
+        assert!(
+            difference < 1e-30,
+            "Mismatch {}: {:?} vs {:?}",
+            difference,
+            expected,
+            result,
         );
     });
 }

--- a/tests/explog_tests.rs
+++ b/tests/explog_tests.rs
@@ -121,15 +121,19 @@ fn ln_1p_test() {
 }
 
 #[test]
-fn exp_ln_test() {
+fn ln_exp_test() {
     let mut rng = rand::thread_rng();
     let src_dist = rand::distributions::Uniform::new(-600.0, 600.0);
 
     repeated_test(|| {
         let expected = TwoFloat::from(rng.sample(src_dist));
-        println!("{:e}", expected);
 
-        let result = expected.exp().ln();
+        // Compensate for when the original number is small
+        let result = if expected.abs() < 0.25 {
+            expected.exp_m1().ln_1p()
+        } else {
+            expected.exp().ln()
+        };
 
         assert!(
             result.is_valid(),


### PR DESCRIPTION
With the previous implementation of exp() we had

```rust
    let one: TwoFloat = 1.0.into();
    println!("EXP({one})");
    println!(" exp: {}", one.exp());
    println!(" ref: {}", twofloat::consts::E);
```

```
EXP(1.0000000000000000000000000000000)
 exp: 2.7182818284590452400177522444638
 ref: 2.7182818284590452353602874713526
  ```
  
  With the new implementation 
  
  ```
  EXP(1.0000000000000000000000000000000)
  exp: 2.7182818284590452353602874713489
  ref: 2.7182818284590452353602874713526
```