### PR TITLE
pretty_str as default display using BigFloat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ std = []
 [dependencies]
 hexf = "0.2"
 libm = { version = "0.2.6" }
+num-bigfloat = "1.7.1"
 num-traits = { version = "0.2.14", default-features = false, features = ["libm"] }
 serde = { version = "1.0", default-features = false, optional = true }
 

--- a/src/format.rs
+++ b/src/format.rs
@@ -1,41 +1,46 @@
 use core::fmt;
+use num_bigfloat::BigFloat;
 
 use crate::TwoFloat;
 
 impl fmt::Display for TwoFloat {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        let sign_char = if self.lo().is_sign_positive() {
-            '+'
-        } else {
-            '-'
-        };
-        if f.sign_plus() {
-            match f.precision() {
-                Some(p) => write!(
-                    f,
-                    "{:+.*} {} {:.*}",
-                    p,
-                    self.hi,
-                    sign_char,
-                    p,
-                    libm::fabs(self.lo)
-                ),
-                None => write!(f, "{:+} {} {}", self.hi, sign_char, libm::fabs(self.lo)),
+        write!(f, "{}", self.pretty_str())
+    }
+}
+
+impl TwoFloat {
+    // Compute number using BigFloat assuming a mantisse of size 53*2-1
+    pub fn pretty_str(&self) -> String {
+        let mut num: BigFloat = 0.0.into();
+        for float in [self.hi, self.lo] {
+            let (mut m, e) = libm::frexp(float);
+            let mut f2: BigFloat = match m.signum() {
+                1.0 => 2f64.powi(e),
+                -1.0 => -(2f64.powi(e)),
+                _ => panic!("Not Implemented"),
             }
-        } else {
-            match f.precision() {
-                Some(p) => write!(
-                    f,
-                    "{:.*} {} {:.*}",
-                    p,
-                    self.hi,
-                    sign_char,
-                    p,
-                    libm::fabs(self.lo)
-                ),
-                None => write!(f, "{} {} {}", self.hi, sign_char, libm::fabs(self.lo)),
+            .into();
+            let mut b: f64;
+            while m != 0.0 {
+                m *= 2.0;
+                f2 /= num_bigfloat::TWO;
+                (m, b) = libm::modf(m);
+                if b.abs() == 1.0 {
+                    num += f2;
+                }
             }
         }
+        // Format String to output by reducing the significant digits to 32
+        let mut num_str = format!("{}", num);
+        if !num.is_zero() {
+            match num_str.find("e") {
+                Some(41) | None => num_str.replace_range(33..41, ""), // Positive
+                Some(42) => num_str.replace_range(34..42, ""),        // Negative
+                _ => panic!("BigFloat should have 40 significant digits"),
+            };
+        }
+        num_str
     }
 }
 


### PR DESCRIPTION
Display numbers as single BigFloat ( related to https://github.com/ajtribick/twofloat/issues/1)

```rust
pretty: 2.7182818284590452353602874713526
split : 2.718281828459045e0 + 1.4456468917292502e-16
```

It would also be a good idea to change the EPSILON from the current one to `2^-105=2.465190329e-32`