### PR TITLE
allow to use iterator to sum directly into TwoFloat

### DIFF
--- a/src/iter.rs
+++ b/src/iter.rs
@@ -26,6 +26,7 @@ fn iter_sum_1() {
     assert_eq!(v_sum, res);
 }
 
+#[cfg(test)]
 #[test]
 fn iter_sum_2() {
     //let v: Vec<TwoFloat> = (1..=10).map(|x| Into::<TwoFloat>::into(x as f64)).collect();

--- a/src/iter.rs
+++ b/src/iter.rs
@@ -1,0 +1,36 @@
+use crate::TwoFloat;
+use num_traits::Zero;
+use std::iter::Sum;
+use std::ops::Add;
+
+impl<T> Sum<T> for TwoFloat
+where
+    Self: Add<T, Output = Self>,
+{
+    fn sum<I>(iter: I) -> Self
+    where
+        I: Iterator<Item = T>,
+    {
+        iter.fold(Self::zero(), <Self>::add)
+    }
+}
+
+#[cfg(test)]
+#[test]
+fn iter_sum_1() {
+    //let v: Vec<TwoFloat> = (1..=10).map(|x| Into::<TwoFloat>::into(x as f64)).collect();
+    let v: Vec<f64> = (1..=100).map(|x| x.into()).collect();
+    let res: TwoFloat = 5050.0.into();
+    let v_sum: TwoFloat = v.iter().sum();
+
+    assert_eq!(v_sum, res);
+}
+
+#[test]
+fn iter_sum_2() {
+    //let v: Vec<TwoFloat> = (1..=10).map(|x| Into::<TwoFloat>::into(x as f64)).collect();
+    let v: Vec<f64> = (1..=108).map(|x| 2f64.powi(-x)).collect();
+    let one: TwoFloat = 1.0.into();
+    let v_sum: TwoFloat = v.iter().sum();
+    assert!(v_sum - one < 1e-32);
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -98,6 +98,8 @@ mod serialization;
 
 pub use base::no_overlap;
 
+pub mod iter;
+
 /// Represents a two-word floating point type, represented as the sum of two
 /// non-overlapping f64 values.
 #[derive(Debug, Default, Clone, Copy)]


### PR DESCRIPTION
Added a new folder where in the future one can add multiple iterators involving TwoFloat

In my case I needed one to cast the sum directly into TwoFloat without having to change the code while running in either f64 or with TwoFloat

The test shows what it does
```rust
#[cfg(test)]
#[test]
fn iter_sum_2() {
    //let v: Vec<TwoFloat> = (1..=10).map(|x| Into::<TwoFloat>::into(x as f64)).collect();
    let v: Vec<f64> = (1..=108).map(|x| 2f64.powi(-x)).collect();
    let one: TwoFloat = 1.0.into();
    let v_sum: TwoFloat = v.iter().sum();
    assert!(v_sum - one < 1e-32);
}
```
A sum of f64 is directly performed inside a TwoFloat container.