### PR TITLE
Make math_funcs mandatory

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,8 +52,8 @@ jobs:
           - { target: x86_64-pc-windows-msvc,    os: windows-latest                  }
           - { target: x86_64-unknown-linux-gnu,  os: ubuntu-latest                   }
         features:
-          - { name: "std",    extra_args: "--features serde"                                  }
-          - { name: "no_std", extra_args: "--no-default-features --features math_funcs,serde" }
+          - { name: "std",    extra_args: "--features serde"                         }
+          - { name: "no_std", extra_args: "--no-default-features --features serde"   }
     env:
       CARGO_CMD: cargo
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,7 @@ name = "twofloat"
 test = true
 
 [features]
-default = ["std", "math_funcs"]
-math_funcs = []
+default = ["std"]
 std = []
 
 [dependencies]

--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ addressed in future releases.
 
 ## Optional features
 
-* `math_funcs` - include mathematical functions (enabled by default)
 * `serde` - enable serialization/deserialization with Serde.
 * `std` - use std mathematical functions instead of libm.
 

--- a/src/functions.rs
+++ b/src/functions.rs
@@ -1,15 +1,10 @@
 pub mod fraction;
 pub mod sign;
 
-#[cfg(feature = "math_funcs")]
 #[macro_use]
 mod function_utils;
 
-#[cfg(feature = "math_funcs")]
 pub mod explog;
-#[cfg(feature = "math_funcs")]
 pub mod hyperbolic;
-#[cfg(feature = "math_funcs")]
 pub mod power;
-#[cfg(feature = "math_funcs")]
 pub mod trigonometry;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,9 +25,8 @@ let e = TwoFloat::new_div(1.0, 7.0);
 
 Basic arithmetic operators and comparisons are available, together with the
 utility functions `abs()`, `is_positive_sign()` and `is_negative_sign()`.
-Mathematical functions are provided if the `math_funcs` feature is enabled
-(this is enabled by default), though the implementations should be regarded
-as preliminary.
+Most mathematical functions defined on `f64` are provided, though the
+implementations should be regarded as preliminary.
 
 Operations on non-finite values are not supported. At the moment this is not
 automatically checked. The `is_valid()` method is provided for this purpose.

--- a/src/num_integration.rs
+++ b/src/num_integration.rs
@@ -242,6 +242,7 @@ impl num_traits::NumCast for TwoFloat {
     }
 }
 
+#[allow(non_snake_case)]
 impl num_traits::FloatConst for TwoFloat {
     #[inline]
     fn E() -> Self {
@@ -795,7 +796,6 @@ binary_ops! {
     }
 }
 
-#[cfg(feature = "math_funcs")]
 binary_ops! {
     fn Pow::pow<'a, 'b>(self: &'a TwoFloat, rhs: &'b f64) -> TwoFloat {
         TwoFloat::powf(*self, (*rhs).into())

--- a/tests/explog_tests.rs
+++ b/tests/explog_tests.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "math_funcs")]
-
 #[macro_use]
 pub mod common;
 

--- a/tests/hyperbolic_tests.rs
+++ b/tests/hyperbolic_tests.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "math_funcs")]
-
 #[macro_use]
 pub mod common;
 

--- a/tests/power_tests.rs
+++ b/tests/power_tests.rs
@@ -1,4 +1,3 @@
-#![cfg(feature = "math_funcs")]
 #![allow(clippy::float_cmp)]
 
 #[macro_use]

--- a/tests/trigonometry_tests.rs
+++ b/tests/trigonometry_tests.rs
@@ -1,5 +1,3 @@
-#![cfg(feature = "math_funcs")]
-
 #[macro_use]
 pub mod common;
 


### PR DESCRIPTION
Fixes infinite recursion in num_traits implementation with `--no-default-features`